### PR TITLE
Change untrusted timer target

### DIFF
--- a/app/flags/agents/flag_2.py
+++ b/app/flags/agents/flag_2.py
@@ -1,7 +1,7 @@
 from app.utility.base_world import BaseWorld
 
 name = 'Understanding trust'
-challenge = 'Change the untrusted agent timer to 90 seconds.'
+challenge = 'Change the untrusted agent timer to 60 seconds.'
 extra_info = """Agents beacon into the C2 on a regular basis, asking the adversary if there are new instructions.
 If a beacon misses a regularly scheduled interval, there is a chance the agent itself has been discovered and
 compromised. Defenders may attempt to reverse-engineer the agent and restart it with the intent of
@@ -9,6 +9,6 @@ learning how it works. """
 
 
 async def verify(services):
-    if BaseWorld.get_config(name='agents', prop='untrusted_timer') == 90:
+    if BaseWorld.get_config(name='agents', prop='untrusted_timer') == 60:
         return True
     return False


### PR DESCRIPTION
It should be different from the default in https://github.com/mitre/caldera/blob/master/conf/agents.yml#L6 so users don't automatically get the flag.