### PR TITLE
Fix Advanced flags

### DIFF
--- a/app/flags/advanced/flag_1.py
+++ b/app/flags/advanced/flag_1.py
@@ -1,5 +1,5 @@
 name = 'Adjust sources'
-challenge = 'Create an entirely new fact source called "better_basic" with at least 1 trait and 1 rule'
+challenge = 'Create an entirely new fact source called "better basic" with at least 1 trait and 1 rule'
 extra_info = """As an adversary runs TTPs on a host, they look at the output and pick out indicators of interest. These may be
 things like user names or passwords, locations of other computers in the network or other useful information. An
 adversary makes note of these indicators to use in future TTPs."""

--- a/app/flags/advanced/flag_2.py
+++ b/app/flags/advanced/flag_2.py
@@ -5,4 +5,4 @@ extra_info = """In a red-team engagement, there are usually multiple operators s
 
 async def verify(services):
     user = services.get('auth_svc').user_map.get('test')
-    return 'red' in user[2]
+    return user and 'red' in user[2]


### PR DESCRIPTION
Instructions for flag_1 were incorrect.

flag_2 produced errors before the 'test' user was added ("'NoneType' object is not subscriptable").