### PR TITLE
Fix "Combine Adversary Profiles" flag

### DIFF
--- a/app/flags/adversaries/flag_1.py
+++ b/app/flags/adversaries/flag_1.py
@@ -8,6 +8,6 @@ CALDERA, this chain of TTPs being used is considered an adversary."""
 async def verify(services):
     for a in await services.get('data_svc').locate('adversaries', dict(name='Certifiable')):
         for ability in a.atomic_ordering:
-            if ability.ability_id == '2fe2d5e6-7b06-4fc0-bf71-6966a1226731':
+            if ability == '2fe2d5e6-7b06-4fc0-bf71-6966a1226731':
                 return True
     return False


### PR DESCRIPTION
Issue in "Combine Adversary Profiles" flag prevents flag completion. `ability` is a string, but was treated as an object.