### PR TITLE
Added chain length check to 'Base64 Operation', removed from 'Basic Op'

### DIFF
--- a/app/flags/operations/flag_0.py
+++ b/app/flags/operations/flag_0.py
@@ -7,6 +7,6 @@ emulation exercises, ensuring that each one is identical to the last."""
 
 async def verify(services):
     for op in await services.get('data_svc').locate('operations'):
-        if op.finish and len(op.chain) > 5 and op.adversary.adversary_id == 'de07f52d-9928-4071-9142-cb1d3bd851e8':
+        if op.finish and op.adversary.adversary_id == 'de07f52d-9928-4071-9142-cb1d3bd851e8':
             return True
     return False

--- a/app/flags/operations/flag_1.py
+++ b/app/flags/operations/flag_1.py
@@ -10,6 +10,6 @@ commands, they can bypass this sort of detection tactic."""
 async def verify(services):
     for op in await services.get('data_svc').locate('operations'):
         if op.finish and op.adversary.adversary_id != 'de07f52d-9928-4071-9142-cb1d3bd851e8' \
-                and op.obfuscator == 'base64' and op.jitter == '10/20':
+                and op.obfuscator == 'base64' and op.jitter == '10/20' and len(op.chain) >= 5:
             return True
     return False


### PR DESCRIPTION
The "Base64 Operation" flag specifies "At least 5 abilities should execute". Added the check to the flag. The "Basic Operation" flag does not specify a chain length, so the check has been removed.