### PR TITLE
Reworked new user flag

### DIFF
--- a/app/flags/advanced/flag_2.py
+++ b/app/flags/advanced/flag_2.py
@@ -1,8 +1,8 @@
 name = 'Add new user'
-challenge = 'Add new red-team user credentials for username=test and password=test. Then log in under this user.'
+challenge = 'Add new red-team user credentials, using "test" as both the username and password.'
 extra_info = """In a red-team engagement, there are usually multiple operators sharing access to the C2."""
 
 
 async def verify(services):
     user = services.get('auth_svc').user_map.get('test')
-    return user and 'red' in user[2]
+    return user and user.password == 'test' and 'red' in user.permissions


### PR DESCRIPTION
Previously checked for the existence of a user with the username "test", then confirmed that the user had "red" permissions. Description additionally requested that the user use "test" as the password and that the user be logged in.

Reworked to include check for "test" as the password. Also changed the permissions check to use the "permissions" key. Removed the requirement to log in as this user, as checking this does not appear to be possible.