### PR TITLE
Setting all files and operations to have hidden access

### DIFF
--- a/app/base_flag.py
+++ b/app/base_flag.py
@@ -16,7 +16,7 @@ class BaseFlag:
 
     @staticmethod
     async def start_operation(services, op_name, group, adv_id):
-        access = dict(access=[BaseWorld.Access.RED])
+        access = dict(access=[BaseWorld.Access.HIDDEN])
         data = dict(name=op_name, group=group, adversary_id=adv_id,
                     planner='batch', atomic_enabled=1, hidden=True)
         await services.get('rest_svc').create_operation(access=access, data=data)

--- a/hook.py
+++ b/hook.py
@@ -1,5 +1,6 @@
 import glob
 from importlib import import_module
+import os
 
 from app.utility.base_world import BaseWorld
 from plugins.training.app.c_badge import Badge
@@ -22,6 +23,25 @@ async def enable(services):
     app.router.add_static('/training', 'plugins/training/static/', append_version=True)
     app.router.add_route('GET', '/plugin/training/gui', training_api.splash)
     app.router.add_route('POST', '/plugin/training/flags', training_api.retrieve_flags)
+
+
+async def expansion(services):
+    data_svc = services.get('data_svc')
+    await _apply_hidden_access_to_loaded_files(data_svc)
+
+
+async def _apply_hidden_access_to_loaded_files(data_svc):
+    object_types = ['abilities', 'adversaries']
+    for obj_typ in object_types:
+        for filename in glob.iglob('plugins/training/data/'+obj_typ+'/**/*.yml', recursive=True):
+            obj_id = os.path.splitext(os.path.basename(filename))[0]
+            if obj_typ == 'abilities':
+                match = dict(ability_id=obj_id)
+            else:
+                match = dict(adversary_id=obj_id)
+            objects = await data_svc.locate(obj_typ, match=match)
+            for obj in objects:
+                obj.access = BaseWorld.Access.HIDDEN
 
 
 async def _load_flags(data_svc):


### PR DESCRIPTION
Abilities, adversaries, and operations will be assigned HIDDEN access, preventing them from being visible on the front end. Relies on https://github.com/mitre/caldera/pull/1734/files