### PR TITLE
modified flag text to specify Public user directory

### DIFF
--- a/app/flags/autonomous/blue_2.py
+++ b/app/flags/autonomous/blue_2.py
@@ -2,8 +2,8 @@ from app.utility.base_world import BaseWorld
 
 
 name = 'Malicious file on system'
-challenge = 'Write a file on the Windows machine under the C:\\Users directory. Get the SHA256 hash of this file, ' \
-            'and write it to C:\\Users\\Public\\malicious_files.txt. The autonomous defender should ' \
+challenge = 'Write a file on the Windows machine under the C:\\Users\\Public directory. Get the SHA256 hash of this ' \
+            'file, and write it to C:\\Users\\Public\\malicious_files.txt. The autonomous defender should ' \
             'automatically find and delete the file.'
 extra_info = """"""
 


### PR DESCRIPTION
Flag specifies user to place malicious file in C:\Users\Public directory, as the relevant Response plugin ability now only looks in that directory. Linked to https://github.com/mitre/response/pull/48