### PR TITLE
VIRTS1565 Training Flag Refactor

### DIFF
--- a/app/base_flag.py
+++ b/app/base_flag.py
@@ -57,7 +57,7 @@ class BaseFlag:
         if await BaseFlag.does_agent_exist(services, agent_group):
             if not (await BaseFlag.is_operation_started(services, operation_name)):
                 await BaseFlag.start_operation(services, operation_name, agent_group, adversary_id)
-            if await BaseFlag.is_operation_successful(services, operation_name) and await is_flag_satisfied(services):
+            if await BaseFlag.is_operation_successful(services, operation_name) and await is_flag_satisfied():
                 await BaseFlag.cleanup_operation(services, operation_name)
                 return True
         return False

--- a/app/c_fillinblank.py
+++ b/app/c_fillinblank.py
@@ -3,10 +3,10 @@ from app.utility.base_object import BaseObject
 
 
 class FillInBlank(Flag, BaseObject):
+    answer = None
 
-    def __init__(self, number, name, challenge, answer, extra_info=''):
-        super().__init__(number, name, challenge, extra_info=extra_info)
-        self.answer = answer
+    def __init__(self, number):
+        super().__init__(number)
         self.flag_type = 'fillinblank'
 
     @property

--- a/app/c_fillinblank.py
+++ b/app/c_fillinblank.py
@@ -5,7 +5,7 @@ from app.utility.base_object import BaseObject
 class FillInBlank(Flag, BaseObject):
 
     def __init__(self, number, name, challenge, answer, extra_info=''):
-        super().__init__(number, name, challenge, self.verify, extra_info=extra_info)
+        super().__init__(number, name, challenge, extra_info=extra_info)
         self.answer = answer
         self.flag_type = 'fillinblank'
 

--- a/app/c_flag.py
+++ b/app/c_flag.py
@@ -48,13 +48,12 @@ class Flag(BaseObject, metaclass=RegisterLeafClasses):
                     resettable='True' if self.additional_fields and 'adversary_id' in self.additional_fields
                     else 'False')
 
-    def __init__(self, number, name, challenge, verify, extra_info='', additional_fields=None):
+    def __init__(self, number, name, challenge, extra_info='', additional_fields=None):
         super().__init__()
         self.number = number
         self.name = name
         self.challenge = challenge
         self.extra_info = extra_info
-        self.verify = verify
         self.additional_fields = additional_fields
         self._completed = False
         self._completed_timestamp = None

--- a/app/c_flag.py
+++ b/app/c_flag.py
@@ -18,6 +18,10 @@ class RegisterLeafClasses(type):
 
 
 class Flag(BaseObject, metaclass=RegisterLeafClasses):
+    name = None
+    challenge = None
+    extra_info = None
+    additional_fields = None
 
     @property
     def unique(self):
@@ -48,13 +52,9 @@ class Flag(BaseObject, metaclass=RegisterLeafClasses):
                     resettable='True' if self.additional_fields and 'adversary_id' in self.additional_fields
                     else 'False')
 
-    def __init__(self, number, name, challenge, extra_info='', additional_fields=None):
+    def __init__(self, number):
         super().__init__()
         self.number = number
-        self.name = name
-        self.challenge = challenge
-        self.extra_info = extra_info
-        self.additional_fields = additional_fields
         self._completed = False
         self._completed_timestamp = None
         self._started_ts = None

--- a/app/c_flag.py
+++ b/app/c_flag.py
@@ -5,19 +5,7 @@ from datetime import datetime
 from app.utility.base_object import BaseObject
 
 
-class RegisterLeafClasses(type):
-    # https://python-3-patterns-idioms-test.readthedocs.io/en/latest/Metaprogramming.html#example-self-registration-of-subclasses
-    def __init__(cls, name, bases, nmspc):
-        super(RegisterLeafClasses, cls).__init__(name, bases, nmspc)
-        if not hasattr(cls, 'registry'):
-            cls.registry = dict()
-        if cls not in cls.registry.keys():
-            cls.registry[cls] = dict(module_name=cls.__module__)
-        if bases[0] in cls.registry.keys():
-            cls.registry.pop(bases[0])
-
-
-class Flag(BaseObject, metaclass=RegisterLeafClasses):
+class Flag(BaseObject):
     name = None
     challenge = None
     extra_info = None

--- a/app/c_flag.py
+++ b/app/c_flag.py
@@ -12,7 +12,7 @@ class RegisterLeafClasses(type):
         if not hasattr(cls, 'registry'):
             cls.registry = dict()
         if cls not in cls.registry.keys():
-            cls.registry[cls] = dict(module=cls.__module__, base=cls.__base__)
+            cls.registry[cls] = dict(module_name=cls.__module__, base=cls.__base__)
         if bases[0] in cls.registry.keys():
             cls.registry.pop(bases[0])
 

--- a/app/c_flag.py
+++ b/app/c_flag.py
@@ -12,7 +12,7 @@ class RegisterLeafClasses(type):
         if not hasattr(cls, 'registry'):
             cls.registry = dict()
         if cls not in cls.registry.keys():
-            cls.registry[cls] = dict(module_name=cls.__module__, base=cls.__base__)
+            cls.registry[cls] = dict(module_name=cls.__module__)
         if bases[0] in cls.registry.keys():
             cls.registry.pop(bases[0])
 
@@ -91,16 +91,16 @@ class Flag(BaseObject, metaclass=RegisterLeafClasses):
 
     @staticmethod
     def _is_unauth_process_killed(op):
-        return any(lnk.ability.ability_id == '02fb7fa9-8886-4330-9e65-fa7bb1bc5271' for lnk in op.chain if lnk.finish)
+        return op.ran_ability_id('02fb7fa9-8886-4330-9e65-fa7bb1bc5271')
 
     @staticmethod
     def _is_unauth_process_detected(op):
         return all(trait in [f.trait for f in op.all_facts()] for trait in
                    ['remote.port.unauthorized', 'host.pid.unauthorized']) and \
-               '3b4640bc-eacb-407a-a997-105e39788781' in [link.ability.ability_id for link in op.chain if link.finish]
+               op.ran_ability_id('3b4640bc-eacb-407a-a997-105e39788781')
 
     @staticmethod
     def _is_file_found(op):
         return all(trait in [f.trait for f in op.all_facts()] for trait in
                    ['file.malicious.hash', 'host.malicious.file']) and \
-               'f9b3eff0-e11c-48de-9338-1578b351b14b' in [link.ability.ability_id for link in op.chain if link.finish]
+               op.ran_ability_id('f9b3eff0-e11c-48de-9338-1578b351b14b')

--- a/app/c_multiplechoice.py
+++ b/app/c_multiplechoice.py
@@ -3,12 +3,12 @@ from app.utility.base_object import BaseObject
 
 
 class MultipleChoice(Flag, BaseObject):
+    answer = None
+    options = None
+    multi_select = False
 
-    def __init__(self, number, name, challenge, options, multi_select, answer, extra_info=''):
-        super().__init__(number, name, challenge, extra_info=extra_info)
-        self.answer = answer
-        self.options = options
-        self.multi_select = multi_select
+    def __init__(self, number):
+        super().__init__(number)
         self.flag_type = 'multiplechoice'
 
     @property

--- a/app/c_multiplechoice.py
+++ b/app/c_multiplechoice.py
@@ -5,7 +5,7 @@ from app.utility.base_object import BaseObject
 class MultipleChoice(Flag, BaseObject):
 
     def __init__(self, number, name, challenge, options, multi_select, answer, extra_info=''):
-        super().__init__(number, name, challenge, self.verify, extra_info=extra_info)
+        super().__init__(number, name, challenge, extra_info=extra_info)
         self.answer = answer
         self.options = options
         self.multi_select = multi_select

--- a/app/c_navigator.py
+++ b/app/c_navigator.py
@@ -9,10 +9,10 @@ class Navigator(Flag, BaseObject):
     Type of flag that checks if a provided ATT&CK Navigator layer file contains the required (Tactic, Technique)
     mappings
     """
+    answer = None
 
-    def __init__(self, number, name, challenge, answer, extra_info=''):
-        super().__init__(number, name, challenge, extra_info=extra_info)
-        self.answer = answer
+    def __init__(self, number):
+        super().__init__(number)
         self.flag_type = 'navigator'
 
     @property

--- a/app/c_navigator.py
+++ b/app/c_navigator.py
@@ -11,7 +11,7 @@ class Navigator(Flag, BaseObject):
     """
 
     def __init__(self, number, name, challenge, answer, extra_info=''):
-        super().__init__(number, name, challenge, self.verify, extra_info=extra_info)
+        super().__init__(number, name, challenge, extra_info=extra_info)
         self.answer = answer
         self.flag_type = 'navigator'
 

--- a/app/flags/advanced/flag_0.py
+++ b/app/flags/advanced/flag_0.py
@@ -1,11 +1,14 @@
-name = 'Update configs'
-challenge = 'Update the app.contact.http configuration property to the local ipv4 address'
-extra_info = """Adversaries will often make their C2 server available behind a proxy. Doing this allows them to hide their own IP
-address while maintaining local control of the server on their local machine."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    http_contact = services.get('app_svc').get_config('app.http.contact')
-    if http_contact != 'http://127.0.0.1:8888':
-        return True
-    return False
+class AdvancedFlag0(Flag):
+    name = 'Update configs'
+    challenge = 'Update the app.contact.http configuration property to the local ipv4 address'
+    extra_info = """Adversaries will often make their C2 server available behind a proxy. Doing this allows them to 
+    hide their own IP address while maintaining local control of the server on their local machine."""
+
+    async def verify(self, services):
+        http_contact = services.get('app_svc').get_config('app.http.contact')
+        if http_contact != 'http://127.0.0.1:8888':
+            return True
+        return False

--- a/app/flags/advanced/flag_1.py
+++ b/app/flags/advanced/flag_1.py
@@ -1,15 +1,18 @@
-name = 'Adjust sources'
-challenge = 'Create an entirely new fact source called "better basic" with at least 1 trait and 1 rule'
-extra_info = """As an adversary runs TTPs on a host, they look at the output and pick out indicators of interest. These may be
-things like user names or passwords, locations of other computers in the network or other useful information. An
-adversary makes note of these indicators to use in future TTPs."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    check1, check2 = False, False
-    for source in await services.get('data_svc').locate('sources', dict(name='better basic')):
-        if len(source.facts) > 0:
-            check1 = True
-        if len(source.rules) > 0:
-            check2 = True
-    return all([check1, check2])
+class AdvancedFlag1(Flag):
+    name = 'Adjust sources'
+    challenge = 'Create an entirely new fact source called "better basic" with at least 1 trait and 1 rule'
+    extra_info = """As an adversary runs TTPs on a host, they look at the output and pick out indicators of interest. These may be
+    things like user names or passwords, locations of other computers in the network or other useful information. An
+    adversary makes note of these indicators to use in future TTPs."""
+
+    async def verify(self, services):
+        check1, check2 = False, False
+        for source in await services.get('data_svc').locate('sources', dict(name='better basic')):
+            if len(source.facts) > 0:
+                check1 = True
+            if len(source.rules) > 0:
+                check2 = True
+        return all([check1, check2])

--- a/app/flags/advanced/flag_2.py
+++ b/app/flags/advanced/flag_2.py
@@ -1,9 +1,12 @@
-name = 'Add new user'
-challenge = 'Add new red-team user credentials, using "test" as both the username and password. Make sure ' \
-            'the server is turned off before editing the configuration files.'
-extra_info = """In a red-team engagement, there are usually multiple operators sharing access to the C2."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    user = services.get('auth_svc').user_map.get('test')
-    return user and user.password == 'test' and 'red' in user.permissions
+class AdvancedFlag2(Flag):
+    name = 'Add new user'
+    challenge = 'Add new red-team user credentials, using "test" as both the username and password. Make sure ' \
+                'the server is turned off before editing the configuration files.'
+    extra_info = """In a red-team engagement, there are usually multiple operators sharing access to the C2."""
+
+    async def verify(self, services):
+        user = services.get('auth_svc').user_map.get('test')
+        return user and user.password == 'test' and 'red' in user.permissions

--- a/app/flags/adversaries/flag_0.py
+++ b/app/flags/adversaries/flag_0.py
@@ -1,11 +1,14 @@
-name = 'Create adversary'
-challenge = 'Create a new adversary named "Certifiable" with at least 3 abilities'
-extra_info = """An adversary usually executes their attack in a specific order, one technique at a time. It's common to start with
-discovery - or recon - of what is on the compromised host. Then moving to collection, persistence or
-lateral-movement, an adversary continues on."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    for a in await services.get('data_svc').locate('adversaries', dict(name='Certifiable')):
-        return len(a.atomic_ordering) >= 3
-    return False
+class AdversariesFlag0(Flag):
+    name = 'Create adversary'
+    challenge = 'Create a new adversary named "Certifiable" with at least 3 abilities'
+    extra_info = """An adversary usually executes their attack in a specific order, one technique at a time. It's 
+    common to start with discovery - or recon - of what is on the compromised host. Then moving to collection, 
+    persistence or lateral-movement, an adversary continues on."""
+
+    async def verify(self, services):
+        for a in await services.get('data_svc').locate('adversaries', dict(name='Certifiable')):
+            return len(a.atomic_ordering) >= 3
+        return False

--- a/app/flags/adversaries/flag_1.py
+++ b/app/flags/adversaries/flag_1.py
@@ -1,13 +1,16 @@
-name = 'Combine adversaries'
-challenge = 'Add the Nosy Neighbor adversary to the Certifiable adversary and save it'
-extra_info = """A TTP is often connected to a series of other TTPs to form an attack. For example, an adversary may have a procedure
-for locating all PDF files on a host. This may be followed by a procedure to exfiltrate all the found files. In
-CALDERA, this chain of TTPs being used is considered an adversary."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    for a in await services.get('data_svc').locate('adversaries', dict(name='Certifiable')):
-        for ability in a.atomic_ordering:
-            if ability == '2fe2d5e6-7b06-4fc0-bf71-6966a1226731':
-                return True
-    return False
+class AdversariesFlag1(Flag):
+    name = 'Combine adversaries'
+    challenge = 'Add the Nosy Neighbor adversary to the Certifiable adversary and save it'
+    extra_info = """A TTP is often connected to a series of other TTPs to form an attack. For example, an adversary may 
+    have a procedure for locating all PDF files on a host. This may be followed by a procedure to exfiltrate all the 
+    found files. In CALDERA, this chain of TTPs being used is considered an adversary."""
+
+    async def verify(self, services):
+        for a in await services.get('data_svc').locate('adversaries', dict(name='Certifiable')):
+            for ability in a.atomic_ordering:
+                if ability == '2fe2d5e6-7b06-4fc0-bf71-6966a1226731':
+                    return True
+        return False

--- a/app/flags/adversaries/flag_2.py
+++ b/app/flags/adversaries/flag_2.py
@@ -1,16 +1,20 @@
-name = 'Create ability'
-challenge = 'Create a new ability from the UI named "My test ability" and add it to the Certifiable adversary. Put ' \
-            'it under the discovery tactic and include a command to execute and a cleanup command. Have the command ' \
-            'print out the network interfaces and IP addresses on the host. Hint: this would be "ifconfig" on a MacOS.'
-extra_info = """Being able to create TTPs quickly and swap them in and out is a valuable skill. Adversaries use a
- TTP until it is no longer effective - and then they write new versions, make modifications or switch techniques
- entirely."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    check1, check2, check3 = False, False, False
-    for a in await services.get('data_svc').locate('abilities', dict(name='My test ability')):
-        check1 = a.tactic == 'discovery'
-        check2 = a.payloads is not None
-        check3 = a.cleanup is not None
-    return all([check1, check2, check3])
+class AdversariesFlag2(Flag):
+    name = 'Create ability'
+    challenge = 'Create a new ability from the UI named "My test ability" and add it to the Certifiable adversary. ' \
+                'Put it under the discovery tactic and include a command to execute and a cleanup command. Have the ' \
+                'command print out the network interfaces and IP addresses on the host. Hint: this would be ' \
+                '"ifconfig" on a MacOS.'
+    extra_info = """Being able to create TTPs quickly and swap them in and out is a valuable skill. Adversaries use a
+     TTP until it is no longer effective - and then they write new versions, make modifications or switch techniques
+     entirely."""
+
+    async def verify(self, services):
+        check1, check2, check3 = False, False, False
+        for a in await services.get('data_svc').locate('abilities', dict(name='My test ability')):
+            check1 = a.tactic == 'discovery'
+            check2 = a.payloads is not None
+            check3 = a.cleanup is not None
+        return all([check1, check2, check3])

--- a/app/flags/agents/blue_0.py
+++ b/app/flags/agents/blue_0.py
@@ -1,11 +1,14 @@
-name = 'Red agent - *nix'
-challenge = 'Deploy a red agent on a Linux or Mac/Darwin machine with a group named exactly \'cert-nix\'. This agent ' \
-            'will be used in later challenges.'
-extra_info = """"""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    for agent in await services.get('data_svc').locate('agents'):
-        if agent.platform in ['linux', 'darwin'] and agent.group == 'cert-nix':
-            return True
-    return False
+class AgentsBlue0(Flag):
+    name = 'Red agent - *nix'
+    challenge = 'Deploy a red agent on a Linux or Mac/Darwin machine with a group named exactly \'cert-nix\'. ' \
+                'This agent will be used in later challenges.'
+    extra_info = """"""
+
+    async def verify(self, services):
+        for agent in await services.get('data_svc').locate('agents'):
+            if agent.platform in ['linux', 'darwin'] and agent.group == 'cert-nix':
+                return True
+        return False

--- a/app/flags/agents/blue_1.py
+++ b/app/flags/agents/blue_1.py
@@ -1,11 +1,14 @@
-name = 'Blue agent - *nix'
-challenge = 'Deploy a blue agent on a Linux or Mac/Darwin machine. Ensure that this agent has ELEVATED privileges. ' \
-            'This agent will be used in later challenges.'
-extra_info = """"""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    for agent in await services.get('data_svc').locate('agents'):
-        if agent.platform in ['linux', 'darwin'] and agent.group == 'blue' and agent.privilege == 'Elevated':
-            return True
-    return False
+class AgentsBlue1(Flag):
+    name = 'Blue agent - *nix'
+    challenge = 'Deploy a blue agent on a Linux or Mac/Darwin machine. Ensure that this agent has ELEVATED ' \
+                'privileges. This agent will be used in later challenges.'
+    extra_info = """"""
+
+    async def verify(self, services):
+        for agent in await services.get('data_svc').locate('agents'):
+            if agent.platform in ['linux', 'darwin'] and agent.group == 'blue' and agent.privilege == 'Elevated':
+                return True
+        return False

--- a/app/flags/agents/blue_2.py
+++ b/app/flags/agents/blue_2.py
@@ -1,11 +1,14 @@
-name = 'Red agent - Windows'
-challenge = 'Deploy a red agent on a Windows machine with a group named exactly \'cert-win\'. This agent will be used' \
-            ' in later challenges.'
-extra_info = """"""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    for agent in await services.get('data_svc').locate('agents'):
-        if 'win' in agent.platform and agent.group == 'cert-win':
-            return True
-    return False
+class AgentsBlue2(Flag):
+    name = 'Red agent - Windows'
+    challenge = 'Deploy a red agent on a Windows machine with a group named exactly \'cert-win\'. This agent will be ' \
+                'used in later challenges.'
+    extra_info = """"""
+
+    async def verify(self, services):
+        for agent in await services.get('data_svc').locate('agents'):
+            if 'win' in agent.platform and agent.group == 'cert-win':
+                return True
+        return False

--- a/app/flags/agents/blue_3.py
+++ b/app/flags/agents/blue_3.py
@@ -1,11 +1,14 @@
-name = 'Blue agent - Windows'
-challenge = 'Deploy a blue agent on a Windows machine. Ensure that this agent has ELEVATED privileges. ' \
-            'This agent will be used in later challenges.'
-extra_info = """"""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    for agent in await services.get('data_svc').locate('agents'):
-        if 'win' in agent.platform and agent.group == 'blue' and agent.privilege == 'Elevated':
-            return True
-    return False
+class AgentsBlue3(Flag):
+    name = 'Blue agent - Windows'
+    challenge = 'Deploy a blue agent on a Windows machine. Ensure that this agent has ELEVATED privileges. ' \
+                'This agent will be used in later challenges.'
+    extra_info = """"""
+
+    async def verify(self, services):
+        for agent in await services.get('data_svc').locate('agents'):
+            if 'windows' in agent.platform and agent.group == 'blue' and agent.privilege == 'Elevated':
+                return True
+        return False

--- a/app/flags/agents/flag_0.py
+++ b/app/flags/agents/flag_0.py
@@ -1,10 +1,14 @@
-name = 'Local agent'
-challenge = 'Demonstrate your ability to deploy an agent on local host. The agent should successfully ' \
-              'beacon back to this server instance.'
-extra_info = """An agent is another name for Remote Access Trojan (RAT). These programs, written in any language, execute an adversary's
-instructions on compromised computers. Often, an agent will communicate back to the adversary through an internet
-protocol, such as HTTP, UDP or DNS. Agents give adversaries remote-control access of the computer running it."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    return len(await services.get('data_svc').locate('agents')) > 0
+class AgentsFlag0(Flag):
+    name = 'Local agent'
+    challenge = 'Demonstrate your ability to deploy an agent on local host. The agent should successfully ' \
+                'beacon back to this server instance.'
+    extra_info = """An agent is another name for Remote Access Trojan (RAT). These programs, written in any language, 
+    execute an adversary's instructions on compromised computers. Often, an agent will communicate back to the 
+    adversary through an internet protocol, such as HTTP, UDP or DNS. Agents give adversaries remote-control access of 
+    the computer running it."""
+
+    async def verify(self, services):
+        return len(await services.get('data_svc').locate('agents')) > 0

--- a/app/flags/agents/flag_1.py
+++ b/app/flags/agents/flag_1.py
@@ -1,22 +1,25 @@
 import sys
 
-name = 'Remote agent'
-challenge = 'Demonstrate your ability to deploy an agent on a remote host. The agent should successfully ' \
-              'beacon back to this server instance. This agent should be run on an operating system that is NOT the ' \
-              'same as what is hosting the server. It is OK to use a virtual box to complete this challenge.'
-extra_info = """Adversaries will most likely deploy their command-and-control (C2) server somewhere Internet accessible.
-This means their agents will need to have access to the C2 IP address. Computers often have unrestricted outbound
-Internet connectivity but heavily restricted inbound connectivity, which is why it's usually best to have an agent
-connect to you, not vice-versa."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    agents = await services.get('data_svc').locate('agents')
-    check1 = len(agents) > 1
-    check2, check3 = False, False
-    for a in agents:
-        if a.platform != sys.platform:
-            check2 = True
-        if a.server not in ['127.0.0.1', 'localhost', '0.0.0.0']:
-            check3 = True
-    return all([check1, check2, check3])
+class AgentsFlag1(Flag):
+    name = 'Remote agent'
+    challenge = 'Demonstrate your ability to deploy an agent on a remote host. The agent should successfully ' \
+                'beacon back to this server instance. This agent should be run on an operating system that is NOT' \
+                ' the same as what is hosting the server. It is OK to use a virtual box to complete this challenge.'
+    extra_info = """Adversaries will most likely deploy their command-and-control (C2) server somewhere Internet 
+    accessible. This means their agents will need to have access to the C2 IP address. Computers often have 
+    unrestricted outbound Internet connectivity but heavily restricted inbound connectivity, which is why it's usually 
+    best to have an agent connect to you, not vice-versa."""
+
+    async def verify(self, services):
+        agents = await services.get('data_svc').locate('agents')
+        check1 = len(agents) > 1
+        check2, check3 = False, False
+        for a in agents:
+            if a.platform != sys.platform:
+                check2 = True
+            if a.server not in ['127.0.0.1', 'localhost', '0.0.0.0']:
+                check3 = True
+        return all([check1, check2, check3])

--- a/app/flags/agents/flag_2.py
+++ b/app/flags/agents/flag_2.py
@@ -1,14 +1,16 @@
 from app.utility.base_world import BaseWorld
-
-name = 'Understanding trust'
-challenge = 'Change the untrusted agent timer to 60 seconds.'
-extra_info = """Agents beacon into the C2 on a regular basis, asking the adversary if there are new instructions.
-If a beacon misses a regularly scheduled interval, there is a chance the agent itself has been discovered and
-compromised. Defenders may attempt to reverse-engineer the agent and restart it with the intent of
-learning how it works. """
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    if BaseWorld.get_config(name='agents', prop='untrusted_timer') == 60:
-        return True
-    return False
+class AgentsFlag2(Flag):
+    name = 'Understanding trust'
+    challenge = 'Change the untrusted agent timer to 60 seconds.'
+    extra_info = """Agents beacon into the C2 on a regular basis, asking the adversary if there are new instructions.
+    If a beacon misses a regularly scheduled interval, there is a chance the agent itself has been discovered and
+    compromised. Defenders may attempt to reverse-engineer the agent and restart it with the intent of
+    learning how it works. """
+
+    async def verify(self, services):
+        if BaseWorld.get_config(name='agents', prop='untrusted_timer') == 60:
+            return True
+        return False

--- a/app/flags/agents/flag_3.py
+++ b/app/flags/agents/flag_3.py
@@ -1,13 +1,16 @@
-name = 'Update agent'
-challenge = 'Pick any agent and change the group and sleep (min and max) values associated to it.'
-extra_info = """If an agent's beacon time is too regular - or predictable - it runs a higher chance of getting caught. It is
-advisable to select a random time range instead of a hard-coded interval. Usually, an adversary will aim to have
-multiple agents deployed on a host, with some frequent beacon times and some infrequent.
-This gives them a backup in case one gets detected."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    for a in await services.get('data_svc').locate('agents'):
-        if a.group != 'red' and a.sleep_min != 30 and a.sleep_max != 60:
-            return True
-    return False
+class AgentsFlag3(Flag):
+    name = 'Update agent'
+    challenge = 'Pick any agent and change the group and sleep (min and max) values associated to it.'
+    extra_info = """If an agent's beacon time is too regular - or predictable - it runs a higher chance of getting 
+    caught. It is advisable to select a random time range instead of a hard-coded interval. Usually, an adversary 
+    will aim to have multiple agents deployed on a host, with some frequent beacon times and some infrequent.
+    This gives them a backup in case one gets detected."""
+
+    async def verify(self, services):
+        for a in await services.get('data_svc').locate('agents'):
+            if a.group != 'red' and a.sleep_min != 30 and a.sleep_max != 60:
+                return True
+        return False

--- a/app/flags/agents/flag_4.py
+++ b/app/flags/agents/flag_4.py
@@ -1,14 +1,16 @@
 from app.utility.base_world import BaseWorld
-
-name = 'Agent filename'
-challenge = 'Ensure that new agents will be named "super_scary" when downloaded on any host. ' \
-            'Note that the extension is automatically appended if necessary.'
-extra_info = """Adversaries try to blend in when they compromise a host. One common tactic is to name
-their agent after a program that is already running on the host. When defenders check process lists
-and file names, the name has a higher chance of blending in."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    if BaseWorld.get_config(name='agents', prop='implant_name') == 'super_scary':
-        return True
-    return False
+class AgentsFlag4(Flag):
+    name = 'Agent filename'
+    challenge = 'Ensure that new agents will be named "super_scary" when downloaded on any host. ' \
+                'Note that the extension is automatically appended if necessary.'
+    extra_info = """Adversaries try to blend in when they compromise a host. One common tactic is to name
+    their agent after a program that is already running on the host. When defenders check process lists
+    and file names, the name has a higher chance of blending in."""
+
+    async def verify(self, services):
+        if BaseWorld.get_config(name='agents', prop='implant_name') == 'super_scary':
+            return True
+        return False

--- a/app/flags/agents/flag_5.py
+++ b/app/flags/agents/flag_5.py
@@ -1,15 +1,17 @@
 from app.utility.base_world import BaseWorld
-
-name = 'Bootstrap abilities'
-challenge = 'Using a Stockpile ability, ensure new agents automatically run "whoami" on their first beacon. Locate the ability ' \
-            'that executes this command and enter the ability id as a bootstrap ability (Hint: Abilities and their id can be ' \
-            'found in the `plugins/stockpile/data/abilities` directory).'
-extra_info = """Depending on the defensive tools installed on a compromised machine, an adversary may need to execute their mission
-quickly before getting detected and shut down. One common tactic is to give each new agent a set of instructions to
-run immediately after sending the first beacon in. These instructions may determine what software is installed on
-the host, to gain persistence or any another tactic."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    abilities = BaseWorld.get_config(name='agents', prop='bootstrap_abilities')
-    return 'c0da588f-79f0-4263-8998-7496b1a40596' in abilities
+class AgentsFlag5(Flag):
+    name = 'Bootstrap abilities'
+    challenge = 'Using a Stockpile ability, ensure new agents automatically run "whoami" on their first beacon. ' \
+                'Locate the ability that executes this command and enter the ability id as a bootstrap ability ' \
+                '(Hint: Abilities and their id can be found in the `plugins/stockpile/data/abilities` directory).'
+    extra_info = """Depending on the defensive tools installed on a compromised machine, an adversary may need to 
+    execute their mission quickly before getting detected and shut down. One common tactic is to give each new agent a 
+    set of instructions to run immediately after sending the first beacon in. These instructions may determine what 
+    software is installed on the host, to gain persistence or any another tactic."""
+
+    async def verify(self, services):
+        abilities = BaseWorld.get_config(name='agents', prop='bootstrap_abilities')
+        return 'c0da588f-79f0-4263-8998-7496b1a40596' in abilities

--- a/app/flags/agents/flag_6.py
+++ b/app/flags/agents/flag_6.py
@@ -1,12 +1,15 @@
-name = 'Contact points'
-challenge = 'Deploy a new agent, using a different contact point then your first agent'
-extra_info = """If an adversary deploys all of their agents on a host using the same protocol, say HTTP, then when their agent is
-detected and shut down, the defenders will likely close access to the C2 over that protocol. Therefore, an adversary
-will want multiple agents on a host, each using a different protocol to talk to the C2. """
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    contacts = set([agent.contact for agent in await services.get('data_svc').locate('agents')])
-    if len(contacts) > 1:
-        return True
-    return False
+class AgentsFlag6(Flag):
+    name = 'Contact points'
+    challenge = 'Deploy a new agent, using a different contact point then your first agent'
+    extra_info = """If an adversary deploys all of their agents on a host using the same protocol, say HTTP, then when 
+    their agent is detected and shut down, the defenders will likely close access to the C2 over that protocol. 
+    Therefore, an adversary will want multiple agents on a host, each using a different protocol to talk to the C2. """
+
+    async def verify(self, services):
+        contacts = set([agent.contact for agent in await services.get('data_svc').locate('agents')])
+        if len(contacts) > 1:
+            return True
+        return False

--- a/app/flags/agents/flag_7.py
+++ b/app/flags/agents/flag_7.py
@@ -1,11 +1,15 @@
-name = 'Kill agent'
-challenge = 'Kill one of your agents through the GUI'
-extra_info = """In red-team engagements, operators often need to clean up the environments under test at the end
-of the testing. Going through box-by-box can be time-consuming, so using automation to auto-stop agents is preferred. """
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    for a in await services.get('data_svc').locate('agents'):
-        if a.watchdog > 0:
-            return True
-    return False
+class AgentsFlag7(Flag):
+    name = 'Kill agent'
+    challenge = 'Kill one of your agents through the GUI'
+    extra_info = """In red-team engagements, operators often need to clean up the environments under test at the end
+    of the testing. Going through box-by-box can be time-consuming, so using automation to auto-stop agents is 
+    preferred. """
+
+    async def verify(self, services):
+        for a in await services.get('data_svc').locate('agents'):
+            if a.watchdog > 0:
+                return True
+        return False

--- a/app/flags/attack/blue_0.py
+++ b/app/flags/attack/blue_0.py
@@ -1,19 +1,20 @@
 from plugins.training.app.base_flag import BaseFlag
-
-name = 'ATT&CK Quiz 1'
-challenge = 'This badge tests your knowledge of ATT&CK techniques. Look on the back of this card for instructions ' \
-            'on how to complete the challenge. Each of the following challenges in this badge will follow the same' \
-            ' process. Ensure the uploaded adversary layer is named exactly \'blue_quiz_1\'.\n\n' \
-            'The adversary procedure is:\nwhoami'
-extra_info = 'Complete the challenge by determining the ONE ATT&CK technique that best matches the procedure on the ' \
-             'front of this card. Select this technique in the Compass plugin and give it a positive score. Rename ' \
-             'the layer as indicated on the front of this card, and then download the layer. Upload the downloaded ' \
-             'layer to the server by selecting \'Upload Adversary Layer\'. Use the help button on the Compass ' \
-             'plugin modal for reference.'
-
-technique = 'T1033'  # System Owner User Discovery
-adv_name = 'blue_quiz_1'
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    return await BaseFlag.verify_attack_flag(services, technique, adv_name)
+class AttackBlue0(Flag):
+    name = 'ATT&CK Quiz 1'
+    challenge = 'This badge tests your knowledge of ATT&CK techniques. Look on the back of this card for ' \
+                'instructions on how to complete the challenge. Each of the following challenges in this badge will ' \
+                'follow the same process. Ensure the uploaded adversary layer is named exactly \'blue_quiz_1\'.\n\n' \
+                'The adversary procedure is:\nwhoami'
+    extra_info = 'Complete the challenge by determining the ONE ATT&CK technique that best matches the procedure on ' \
+                 'the front of this card. Select this technique in the Compass plugin and give it a positive score. ' \
+                 'Rename the layer as indicated on the front of this card, and then download the layer. Upload the ' \
+                 'downloaded layer to the server by selecting \'Upload Adversary Layer\'. Use the help button on the ' \
+                 'Compass plugin modal for reference.'
+
+    async def verify(self, services):
+        technique = 'T1033'  # System Owner User Discovery
+        adv_name = 'blue_quiz_1'
+        return await BaseFlag.verify_attack_flag(services, technique, adv_name)

--- a/app/flags/attack/blue_1.py
+++ b/app/flags/attack/blue_1.py
@@ -1,14 +1,15 @@
 from plugins.training.app.base_flag import BaseFlag
-
-name = 'ATT&CK Quiz 2'
-challenge = 'Refer to \'ATT&CK Quiz 1\' for instructions. Name the uploaded adversary layer exactly \'blue_quiz_2\'. ' \
-            'Ensure that you\'re starting from a fresh layer on the Compass plugin.\n\n' \
-            'The adversary procedure is:\nGet-ChildItem -Path #{host.system.path}'
-extra_info = ''
-
-technique = 'T1083'  # File and Directory Discovery
-adv_name = 'blue_quiz_2'
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    return await BaseFlag.verify_attack_flag(services, technique, adv_name)
+class AttackBlue1(Flag):
+    name = 'ATT&CK Quiz 2'
+    challenge = 'Refer to \'ATT&CK Quiz 1\' for instructions. Name the uploaded adversary layer exactly ' \
+                '\'blue_quiz_2\'. Ensure that you\'re starting from a fresh layer on the Compass plugin.\n\n' \
+                'The adversary procedure is:\nGet-ChildItem -Path #{host.system.path}'
+    extra_info = ''
+
+    async def verify(self, services):
+        technique = 'T1083'  # File and Directory Discovery
+        adv_name = 'blue_quiz_2'
+        return await BaseFlag.verify_attack_flag(services, technique, adv_name)

--- a/app/flags/attack/blue_2.py
+++ b/app/flags/attack/blue_2.py
@@ -1,14 +1,15 @@
 from plugins.training.app.base_flag import BaseFlag
-
-name = 'ATT&CK Quiz 3'
-challenge = 'Refer to \'ATT&CK Quiz 1\' for instructions. Name the uploaded adversary layer exactly \'blue_quiz_3\'. ' \
-            'Ensure that you\'re starting from a fresh layer on the Compass plugin.\n\n' \
-            'The adversary procedure is:\nGet-Clipboard -raw'
-extra_info = ''
-
-technique = 'T1115'  # Clipboard Data
-adv_name = 'blue_quiz_3'
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    return await BaseFlag.verify_attack_flag(services, technique, adv_name)
+class AttackBlue2(Flag):
+    name = 'ATT&CK Quiz 3'
+    challenge = 'Refer to \'ATT&CK Quiz 1\' for instructions. Name the uploaded adversary layer exactly ' \
+                '\'blue_quiz_3\'. Ensure that you\'re starting from a fresh layer on the Compass plugin.\n\n' \
+                'The adversary procedure is:\nGet-Clipboard -raw'
+    extra_info = ''
+
+    async def verify(self, services):
+        technique = 'T1115'  # Clipboard Data
+        adv_name = 'blue_quiz_3'
+        return await BaseFlag.verify_attack_flag(services, technique, adv_name)

--- a/app/flags/attack/blue_3.py
+++ b/app/flags/attack/blue_3.py
@@ -1,14 +1,15 @@
 from plugins.training.app.base_flag import BaseFlag
-
-name = 'ATT&CK Quiz 4'
-challenge = 'Refer to \'ATT&CK Quiz 1\' for instructions. Name the uploaded adversary layer exactly \'blue_quiz_4\'. ' \
-            'Ensure that you\'re starting from a fresh layer on the Compass plugin.\n\n' \
-            'The adversary procedure is:\nImport-Module .\\invoke-mimi.ps1; Invoke-Mimikatz -DumpCreds'
-extra_info = ''
-
-technique = 'T1003'  # Credential Dumping
-adv_name = 'blue_quiz_4'
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    return await BaseFlag.verify_attack_flag(services, technique, adv_name)
+class AttackBlue3(Flag):
+    name = 'ATT&CK Quiz 4'
+    challenge = 'Refer to \'ATT&CK Quiz 1\' for instructions. Name the uploaded adversary layer exactly ' \
+                '\'blue_quiz_4\'. Ensure that you\'re starting from a fresh layer on the Compass plugin.\n\n' \
+                'The adversary procedure is:\nImport-Module .\\invoke-mimi.ps1; Invoke-Mimikatz -DumpCreds'
+    extra_info = ''
+
+    async def verify(self, services):
+        technique = 'T1003'  # Credential Dumping
+        adv_name = 'blue_quiz_4'
+        return await BaseFlag.verify_attack_flag(services, technique, adv_name)

--- a/app/flags/attack/blue_4.py
+++ b/app/flags/attack/blue_4.py
@@ -1,15 +1,16 @@
 from plugins.training.app.base_flag import BaseFlag
-
-name = 'ATT&CK Quiz 5'
-challenge = 'Refer to \'ATT&CK Quiz 1\' for instructions. Name the uploaded adversary layer exactly \'blue_quiz_5\'. ' \
-            'Ensure that you\'re starting from a fresh layer on the Compass plugin.\n\n' \
-            'The adversary procedure is:\nnet /y use \\#{remote.host.name} &' \
-            '\ncopy /y sandcat.go-windows\n\\\\#{remote.host.name}\\Users\\Public'
-extra_info = ''
-
-technique = 'T1105'  # Remote File Copy
-adv_name = 'blue_quiz_5'
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    return await BaseFlag.verify_attack_flag(services, technique, adv_name)
+class AttackBlue4(Flag):
+    name = 'ATT&CK Quiz 5'
+    challenge = 'Refer to \'ATT&CK Quiz 1\' for instructions. Name the uploaded adversary layer exactly ' \
+                '\'blue_quiz_5\'. Ensure that you\'re starting from a fresh layer on the Compass plugin.\n\n' \
+                'The adversary procedure is:\nnet /y use \\#{remote.host.name} &' \
+                '\ncopy /y sandcat.go-windows\n\\\\#{remote.host.name}\\Users\\Public'
+    extra_info = ''
+
+    async def verify(self, services):
+        technique = 'T1105'  # Remote File Copy
+        adv_name = 'blue_quiz_5'
+        return await BaseFlag.verify_attack_flag(services, technique, adv_name)

--- a/app/flags/autonomous/blue_0.py
+++ b/app/flags/autonomous/blue_0.py
@@ -1,16 +1,17 @@
 from app.utility.base_world import BaseWorld
+from plugins.training.app.c_flag import Flag
 
 
-name = 'Enable Autonomous Operation'
-challenge = 'Start an autonomous blue operation using the Incident Responder defender profile. Ensure that the ' \
-            'batch planner is used. Name this operation exactly \'Blue Autonomous\'. Keep this operation open ' \
-            'to successfully complete the flags for this badge.'
-extra_info = """"""
+class AutonomousBlue0(Flag):
+    name = 'Enable Autonomous Operation'
+    challenge = 'Start an autonomous blue operation using the Incident Responder defender profile. Ensure that the ' \
+                'batch planner is used. Name this operation exactly \'Blue Autonomous\'. Keep this operation open ' \
+                'to successfully complete the flags for this badge.'
+    extra_info = """"""
 
-
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Autonomous')):
-        if op.adversary.adversary_id == '7e422753-ad7a-4401-bc8b-b12a28e69c25' and op.planner.name == 'batch':
-            return True
-    return False
+    async def verify(self, services):
+        for op in await services.get('data_svc').locate('operations',
+                                                        match=dict(access=BaseWorld.Access.BLUE, name='Blue Autonomous')):
+            if op.adversary.adversary_id == '7e422753-ad7a-4401-bc8b-b12a28e69c25' and op.planner.name == 'batch':
+                return True
+        return False

--- a/app/flags/autonomous/blue_1.py
+++ b/app/flags/autonomous/blue_1.py
@@ -1,27 +1,17 @@
 from app.utility.base_world import BaseWorld
+from plugins.training.app.c_flag import Flag
 
 
-name = 'Process on Unauthorized Port'
-challenge = 'Start a listening process on Port 7011 on the Linux or Darwin machine (`nc -l 7011` should work). The ' \
-            'autonomous defender created in the last flag (Incident Responder defender profile, batch planner, and ' \
-            'response source) will automatically kill this listener.'
-extra_info = """"""
+class AutonomousBlue1(Flag):
+    name = 'Process on Unauthorized Port'
+    challenge = 'Start a listening process on Port 7011 on the Linux or Darwin machine (`nc -l 7011` should work). ' \
+                'The autonomous defender created in the last flag (Incident Responder defender profile, batch ' \
+                'planner, and response source) will automatically kill this listener.'
+    extra_info = """"""
 
-
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Autonomous')):
-        if is_unauth_process_detected(op) and is_unauth_process_killed(op):
-            return True
-    return False
-
-
-def is_unauth_process_detected(op):
-    if all(trait in [f.trait for f in op.all_facts()] for trait in
-           ['remote.port.unauthorized', 'host.pid.unauthorized']):
-        return True
-    return False
-
-
-def is_unauth_process_killed(op):
-    return '02fb7fa9-8886-4330-9e65-fa7bb1bc5271' in [link.ability.ability_id for link in op.chain if link.finish]
+    async def verify(self, services):
+        for op in await services.get('data_svc').locate('operations',
+                                                        match=dict(access=BaseWorld.Access.BLUE, name='Blue Autonomous')):
+            if self._is_unauth_process_detected(op) and self._is_unauth_process_killed(op):
+                return True
+        return False

--- a/app/flags/autonomous/blue_2.py
+++ b/app/flags/autonomous/blue_2.py
@@ -1,26 +1,21 @@
 from app.utility.base_world import BaseWorld
+from plugins.training.app.c_flag import Flag
 
 
-name = 'Malicious file on system'
-challenge = 'Write a file on the Windows machine under the C:\\Users\\Public directory. Get the SHA256 hash of this ' \
-            'file, and write it to C:\\Users\\Public\\malicious_files.txt. The autonomous defender should ' \
-            'automatically find and delete the file.'
-extra_info = """"""
+class AutonomousBlue2(Flag):
+    name = 'Malicious file on system'
+    challenge = 'Write a file on the Windows machine under the C:\\Users\\Public directory. Get the SHA256 hash of ' \
+                'this file, and write it to C:\\Users\\Public\\malicious_files.txt. The autonomous defender should ' \
+                'automatically find and delete the file.'
+    extra_info = """"""
 
+    async def verify(self, services):
+        def is_file_deleted():
+            return op.ran_ability_id('5ec7ae3b-c909-41bb-9b6b-dadec409cd40')
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Autonomous')):
-        if is_file_found(op) and is_file_deleted(op):
-            return True
-    return False
-
-
-def is_file_found(op):
-    if all(trait in [f.trait for f in op.all_facts()] for trait in ['file.malicious.hash', 'host.malicious.file']):
-        return True
-    return False
-
-
-def is_file_deleted(op):
-    return '5ec7ae3b-c909-41bb-9b6b-dadec409cd40' in [link.ability.ability_id for link in op.chain if link.finish]
+        for op in await services.get('data_svc').locate('operations',
+                                                        match=dict(access=BaseWorld.Access.BLUE,
+                                                                   name='Blue Autonomous')):
+            if self._is_file_found(op) and is_file_deleted():
+                return True
+        return False

--- a/app/flags/autonomous/blue_2.py
+++ b/app/flags/autonomous/blue_2.py
@@ -10,12 +10,12 @@ class AutonomousBlue2(Flag):
     extra_info = """"""
 
     async def verify(self, services):
-        def is_file_deleted():
-            return op.ran_ability_id('5ec7ae3b-c909-41bb-9b6b-dadec409cd40')
+        def is_file_deleted(operation):
+            return operation.ran_ability_id('5ec7ae3b-c909-41bb-9b6b-dadec409cd40')
 
         for op in await services.get('data_svc').locate('operations',
                                                         match=dict(access=BaseWorld.Access.BLUE,
                                                                    name='Blue Autonomous')):
-            if self._is_file_found(op) and is_file_deleted():
+            if self._is_file_found(op) and is_file_deleted(op):
                 return True
         return False

--- a/app/flags/autonomous/blue_3.py
+++ b/app/flags/autonomous/blue_3.py
@@ -10,16 +10,16 @@ class AutonomousBlue3(Flag):
     extra_info = """"""
 
     async def verify(self, services):
-        def is_url_found():
-            return 'remote.suspicious.url' in [f.trait for f in op.all_facts()] \
-                   and op.ran_ability_id('1226f8ec-e2e5-4311-88e7-378c0e5cc7ce')
+        def is_url_found(operation):
+            return 'remote.suspicious.url' in [f.trait for f in operation.all_facts()] \
+                   and operation.ran_ability_id('1226f8ec-e2e5-4311-88e7-378c0e5cc7ce')
 
-        def is_url_inoculated():
-            return op.ran_ability_id('2ca64acd-dc12-4cc8-b78a-6a182508a50b')
+        def is_url_inoculated(operation):
+            return operation.ran_ability_id('2ca64acd-dc12-4cc8-b78a-6a182508a50b')
 
         for op in await services.get('data_svc').locate('operations',
                                                         match=dict(access=BaseWorld.Access.BLUE,
                                                                    name='Blue Autonomous')):
-            if is_url_found() and is_url_inoculated():
+            if is_url_found(op) and is_url_inoculated(op):
                 return True
         return False

--- a/app/flags/autonomous/blue_3.py
+++ b/app/flags/autonomous/blue_3.py
@@ -1,27 +1,25 @@
 from app.utility.base_world import BaseWorld
+from plugins.training.app.c_flag import Flag
 
 
-name = 'Suspicious URL in mail'
-challenge = 'Use the \'mail\' utility to send an email to a user on the Linux or Darwin machine. Spoof the sender ' \
-            'address to be an email address with a fake malicious domain. The autonomous defender should find this ' \
-            'URL and add an entry to the /etc/hosts file, redirecting the URL to localhost.'
-extra_info = """"""
+class AutonomousBlue3(Flag):
+    name = 'Suspicious URL in mail'
+    challenge = 'Use the \'mail\' utility to send an email to a user on the Linux or Darwin machine. Spoof the ' \
+                'sender address to be an email address with a fake malicious domain. The autonomous defender should ' \
+                'find this URL and add an entry to the /etc/hosts file, redirecting the URL to localhost.'
+    extra_info = """"""
 
+    async def verify(self, services):
+        def is_url_found():
+            return 'remote.suspicious.url' in [f.trait for f in op.all_facts()] \
+                   and op.ran_ability_id('1226f8ec-e2e5-4311-88e7-378c0e5cc7ce')
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Autonomous')):
-        if is_url_found(op) and is_url_inoculated(op):
-            return True
-    return False
+        def is_url_inoculated():
+            return op.ran_ability_id('2ca64acd-dc12-4cc8-b78a-6a182508a50b')
 
-
-def is_url_found(op):
-    if 'remote.suspicious.url' in [f.trait for f in op.all_facts()] and \
-            '1226f8ec-e2e5-4311-88e7-378c0e5cc7ce' in [link.ability.ability_id for link in op.chain]:
-        return True
-    return False
-
-
-def is_url_inoculated(op):
-    return '2ca64acd-dc12-4cc8-b78a-6a182508a50b' in [link.ability.ability_id for link in op.chain if link.finish]
+        for op in await services.get('data_svc').locate('operations',
+                                                        match=dict(access=BaseWorld.Access.BLUE,
+                                                                   name='Blue Autonomous')):
+            if is_url_found() and is_url_inoculated():
+                return True
+        return False

--- a/app/flags/developers/flag_0.py
+++ b/app/flags/developers/flag_0.py
@@ -1,18 +1,20 @@
 import glob
-
-name = 'Create a new plugin'
-challenge = 'Build a new plugin named "abilities" where a GUI page displays all the abilities which are ' \
-              'in the database.'
-extra_info = ''
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    check1, check2 = False, False
-    for _ in await services.get('data_svc').locate('plugins', dict(enabled=True, name='abilities')):
-        check1 = True
-        for filename in glob.iglob('plugins/abilities/**/*.html'):
-            with open(filename, 'r') as f:
-                content = f.read()
-                if 'abilities' in content and 'endfor' in content:
-                    check2 = True
-    return all([check1, check2])
+class DevelopersFlag0(Flag):
+    name = 'Create a new plugin'
+    challenge = 'Build a new plugin named "abilities" where a GUI page displays all the abilities which are ' \
+                'in the database.'
+    extra_info = ''
+
+    async def verify(self, services):
+        check1, check2 = False, False
+        for _ in await services.get('data_svc').locate('plugins', dict(enabled=True, name='abilities')):
+            check1 = True
+            for filename in glob.iglob('plugins/abilities/**/*.html'):
+                with open(filename, 'r') as f:
+                    content = f.read()
+                    if 'abilities' in content and 'endfor' in content:
+                        check2 = True
+        return all([check1, check2])

--- a/app/flags/developers/flag_1.py
+++ b/app/flags/developers/flag_1.py
@@ -1,16 +1,19 @@
-name = 'Write a new planner'
-challenge = 'Write a planner called "think_hard" that runs each ability in alphabetical order, ' \
-              'by the ability name. Then run a new operation using this planner, ' \
-            'any group of agents and any profile. At least 10 abilities should run in the operation.'
-extra_info = ''
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations'):
-        if op.finish and op.planner.name == 'think_hard' and len(op.chain) >= 10:
-            alphabetical_op = []
-            for abilities in op.adversary.atomic_ordering:
-                ability_names = [link.ability.name for link in op.chain if link.ability.ability_id in [a.ability_id for a in abilities]]
-                alphabetical_op.append(all(ability_names[i] <= ability_names[i + 1] for i in range(len(ability_names) - 1)))
-            return all(alphabetical_op)
-    return False
+class DevelopersFlag1(Flag):
+    name = 'Write a new planner'
+    challenge = 'Write a planner called "think_hard" that runs each ability in alphabetical order, ' \
+                'by the ability name. Then run a new operation using this planner, ' \
+                'any group of agents and any profile. At least 10 abilities should run in the operation.'
+    extra_info = ''
+
+    async def verify(self, services):
+        for op in await services.get('data_svc').locate('operations'):
+            if op.finish and op.planner.name == 'think_hard' and len(op.chain) >= 10:
+                alphabetical_op = []
+                for abilities in op.adversary.atomic_ordering:
+                    ability_names = [link.ability.name for link in op.chain if link.ability.ability_id in [a.ability_id for a in abilities]]
+                    alphabetical_op.append(all(ability_names[i] <= ability_names[i + 1] for i in range(len(ability_names) - 1)))
+                return all(alphabetical_op)
+        return False

--- a/app/flags/developers/flag_2.py
+++ b/app/flags/developers/flag_2.py
@@ -1,7 +1,10 @@
-name = 'Bypass authentication'
-challenge = 'Ensure that logging in to CALDERA is not required if the browser address is 127.0.0.1'
-extra_info = ''
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    return '127.0.0.1' in services.get('auth_svc').bypass
+class DevelopersFlag2(Flag):
+    name = 'Bypass authentication'
+    challenge = 'Ensure that logging in to CALDERA is not required if the browser address is 127.0.0.1'
+    extra_info = ''
+
+    async def verify(self, services):
+        return '127.0.0.1' in services.get('auth_svc').bypass

--- a/app/flags/developers/flag_3.py
+++ b/app/flags/developers/flag_3.py
@@ -1,25 +1,26 @@
 import socket
-
-name = 'Write new parser'
-challenge = 'Add a new parser which parses IPV6 addresses with the trait, "host.ip.ipv6". ' \
-              'Then run an adversary which correctly parses out matching facts. Hint: use the ability you created ' \
-            'in an earlier flag.'
-extra_info = ''
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations'):
-        if op.finish:
-            found_fact = [fact for fact in op.all_facts() if fact.trait == 'host.ip.ipv6'
-                          and len(fact.value.split(':')) == 8 and _valid_ipv6(fact.value.split(':'))]
-            if len(found_fact) > 0:
+class DevelopersFlag3(Flag):
+    name = 'Write new parser'
+    challenge = 'Add a new parser which parses IPV6 addresses with the trait, "host.ip.ipv6". ' \
+                'Then run an adversary which correctly parses out matching facts. Hint: use the ability you created ' \
+                'in an earlier flag.'
+    extra_info = ''
+
+    async def verify(self, services):
+        def _valid_ipv6(n):
+            try:
+                socket.inet_pton(socket.AF_INET6, n)
                 return True
-    return False
+            except socket.error:
+                return False
 
-
-def _valid_ipv6(n):
-    try:
-        socket.inet_pton(socket.AF_INET6, n)
-        return True
-    except socket.error:
+        for op in await services.get('data_svc').locate('operations'):
+            if op.finish:
+                found_fact = [fact for fact in op.all_facts() if fact.trait == 'host.ip.ipv6'
+                              and len(fact.value.split(':')) == 8 and _valid_ipv6(fact.value.split(':'))]
+                if len(found_fact) > 0:
+                    return True
         return False

--- a/app/flags/developers/flag_4.py
+++ b/app/flags/developers/flag_4.py
@@ -1,19 +1,21 @@
 import os
 
 from app.utility.base_world import BaseWorld
-
-name = 'Add new blue ability'
-challenge = 'Add a new detection ability - manually - to the Response plugin which displays all user names on a host.' \
-              'Ensure this ability will run more than once if used in an operation, then ensure it is ' \
-              'loaded into the database. The ability ID should be abc123.'
-extra_info = ''
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    check1, check2 = False, False
-    if os.path.isfile('plugins/response/data/abilities/detection/abc123.yml'):
-        check1 = True
-        for a in await services.get('data_svc').locate('abilities', dict(ability_id='abc123')):
-            if a.access == BaseWorld.Access.BLUE and a.repeatable:
-                check2 = True
-        return all([check1, check2])
+class DevelopersFlag4(Flag):
+    name = 'Add new blue ability'
+    challenge = 'Add a new detection ability - manually - to the Response plugin which displays all user names on a ' \
+                'host. Ensure this ability will run more than once if used in an operation, then ensure it is ' \
+                'loaded into the database. The ability ID should be abc123.'
+    extra_info = ''
+
+    async def verify(self, services):
+        check1, check2 = False, False
+        if os.path.isfile('plugins/response/data/abilities/detection/abc123.yml'):
+            check1 = True
+            for a in await services.get('data_svc').locate('abilities', dict(ability_id='abc123')):
+                if a.access == BaseWorld.Access.BLUE and a.repeatable:
+                    check2 = True
+            return all([check1, check2])

--- a/app/flags/developers/flag_5.py
+++ b/app/flags/developers/flag_5.py
@@ -1,21 +1,23 @@
 import os
-
-name = 'Special payloads'
-challenge = 'Add a new Stockpile payload called train.txt with the contents "i am a test". Mark it as a ' \
-              'special payload, so when downloaded through the REST api, the payload should return the file with ' \
-              'the text inside reversed each time it is downloaded.'
-extra_info = ''
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    check1, check2 = False, False
-    if os.path.isfile('plugins/stockpile/payloads/train.txt'):
-        with open('plugins/stockpile/payloads/train.txt', 'r') as train:
-            if 'i am a test' in train.read():
-                _, contents, _ = await services.get('file_svc').get_file(dict(file='train.txt'))
-                if contents == reversed('i am a test'):
-                    check1 = True
-                _, contents, _ = await services.get('file_svc').get_file(dict(file='train.txt'))
-                if contents == 'i am a test':
-                    check2 = True
-    return all([check1, check2])
+class DevelopersFlag5(Flag):
+    name = 'Special payloads'
+    challenge = 'Add a new Stockpile payload called train.txt with the contents "i am a test". Mark it as a ' \
+                'special payload, so when downloaded through the REST api, the payload should return the file with ' \
+                'the text inside reversed each time it is downloaded.'
+    extra_info = ''
+
+    async def verify(self, services):
+        check1, check2 = False, False
+        if os.path.isfile('plugins/stockpile/payloads/train.txt'):
+            with open('plugins/stockpile/payloads/train.txt', 'r') as train:
+                if 'i am a test' in train.read():
+                    _, contents, _ = await services.get('file_svc').get_file(dict(file='train.txt'))
+                    if contents == reversed('i am a test'):
+                        check1 = True
+                    _, contents, _ = await services.get('file_svc').get_file(dict(file='train.txt'))
+                    if contents == 'i am a test':
+                        check2 = True
+        return all([check1, check2])

--- a/app/flags/developers/flag_6.py
+++ b/app/flags/developers/flag_6.py
@@ -1,14 +1,17 @@
-name = 'Build an agent'
-challenge = 'Create a new Linux/MacOS agent, using the HTTP contact. This agent should use a new executor - zsh. ' \
-            'You will need to add at least 1 matching zsh ability. Run a new operation against this agent, running ' \
-            'the new ability.'
-extra_info = ''
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations'):
-        if len(op.chain) > 0:
-            for agent in op.agents:
-                if agent.executors == ['zsh']:
-                    return True
-    return False
+class DevelopersFlag6(Flag):
+    name = 'Build an agent'
+    challenge = 'Create a new Linux/MacOS agent, using the HTTP contact. This agent should use a new executor - zsh. ' \
+                'You will need to add at least 1 matching zsh ability. Run a new operation against this agent, ' \
+                'running the new ability.'
+    extra_info = ''
+
+    async def verify(self, services):
+        for op in await services.get('data_svc').locate('operations'):
+            if len(op.chain) > 0:
+                for agent in op.agents:
+                    if agent.executors == ['zsh']:
+                        return True
+        return False

--- a/app/flags/developers/flag_7.py
+++ b/app/flags/developers/flag_7.py
@@ -1,11 +1,13 @@
 from app.utility.base_world import BaseWorld
-
-name = 'Understanding access'
-challenge = 'Change the access of the GameBoard plugin so only blue-team users can access it'
-extra_info = """In a shared C2, you may want to restrict access to specific areas for some users."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    for plugin in await services.get('data_svc').locate('plugins', dict(name='gameboard')):
-        return plugin.access == BaseWorld.Access.BLUE
-    return False
+class DevelopersFlag7(Flag):
+    name = 'Understanding access'
+    challenge = 'Change the access of the GameBoard plugin so only blue-team users can access it'
+    extra_info = """In a shared C2, you may want to restrict access to specific areas for some users."""
+
+    async def verify(self, services):
+        for plugin in await services.get('data_svc').locate('plugins', dict(name='gameboard')):
+            return plugin.access == BaseWorld.Access.BLUE
+        return False

--- a/app/flags/manual/blue_0.py
+++ b/app/flags/manual/blue_0.py
@@ -1,15 +1,16 @@
 from app.utility.base_world import BaseWorld
+from plugins.training.app.c_flag import Flag
 
 
-name = 'Enable Manual Operation'
-challenge = 'Start a manual blue operation by not specifying any defender profiles. Name this operation exactly ' \
-            '\'Blue Manual\'. Keep this operation open to successfully complete the flags for this badge.'
-extra_info = """"""
+class ManualBlue0(Flag):
+    name = 'Enable Manual Operation'
+    challenge = 'Start a manual blue operation by not specifying any defender profiles. Name this operation exactly ' \
+                '\'Blue Manual\'. Keep this operation open to successfully complete the flags for this badge.'
+    extra_info = """"""
 
-
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if op.adversary.adversary_id == 'ad-hoc':
-            return True
-    return False
+    async def verify(self, services):
+        for op in await services.get('data_svc').locate('operations',
+                                                        match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+            if op.adversary.adversary_id == 'ad-hoc':
+                return True
+        return False

--- a/app/flags/manual/blue_1a.py
+++ b/app/flags/manual/blue_1a.py
@@ -1,32 +1,28 @@
 from plugins.training.app.base_flag import BaseFlag
+from plugins.training.app.c_flag import Flag
 from app.utility.base_world import BaseWorld
 
 
-name = 'Detect process on Unauthorized Port'
-challenge = 'Within a minute of this flag activating, a listening process will have been started on port 7011 on ' \
-            'the *nix machine. Run the appropriate detection ability in the \'Blue Manual\' operation to detect ' \
-            'this process.'
-extra_info = """"""
+class ManualBlue1a(Flag):
+    name = 'Detect process on Unauthorized Port'
+    challenge = 'Within a minute of this flag activating, a listening process will have been started on port 7011 on ' \
+                'the *nix machine. Run the appropriate detection ability in the \'Blue Manual\' operation to detect ' \
+                'this process.'
+    extra_info = """"""
+    additional_fields = dict(operation_name='training_manual_1',
+                             adversary_id='72c0b333-f6fe-4fa0-a342-4215e8de3947',
+                             agent_group='cert-nix')
 
-operation_name = 'training_manual_1'
-adversary_id = '72c0b333-f6fe-4fa0-a342-4215e8de3947'
-agent_group = 'cert-nix'
+    async def verify(self, services):
+        async def is_flag_satisfied():
+            for op in await services.get('data_svc').locate('operations',
+                                                            match=dict(access=BaseWorld.Access.BLUE,
+                                                                       name='Blue Manual')):
+                if self._is_unauth_process_detected(op):
+                    return True
+            return False
 
-
-async def verify(services):
-    return await BaseFlag.standard_verify_with_operation(services, operation_name, adversary_id, agent_group,
-                                                         is_flag_satisfied)
-
-
-async def is_flag_satisfied(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if is_unauth_process_detected(op):
-            return True
-    return False
-
-
-def is_unauth_process_detected(op):
-    return all(trait in [f.trait for f in op.all_facts()] for trait in
-               ['remote.port.unauthorized', 'host.pid.unauthorized']) and \
-           '3b4640bc-eacb-407a-a997-105e39788781' in [link.ability.ability_id for link in op.chain if link.finish]
+        return await BaseFlag.standard_verify_with_operation(services, self.additional_fields['operation_name'],
+                                                             self.additional_fields['adversary_id'],
+                                                             self.additional_fields['agent_group'],
+                                                             is_flag_satisfied)

--- a/app/flags/manual/blue_1b.py
+++ b/app/flags/manual/blue_1b.py
@@ -1,19 +1,16 @@
 from app.utility.base_world import BaseWorld
+from plugins.training.app.c_flag import Flag
 
 
-name = 'Kill process on Unauthorized Port'
-challenge = 'Run the appropriate response ability in the \'Blue Manual\' operation to kill the previously found ' \
-            'process.'
-extra_info = """"""
+class ManualBlue1b(Flag):
+    name = 'Kill process on Unauthorized Port'
+    challenge = 'Run the appropriate response ability in the \'Blue Manual\' operation to kill the previously found ' \
+                'process.'
+    extra_info = """"""
 
-
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if is_unauth_process_killed(op):
-            return True
-    return False
-
-
-def is_unauth_process_killed(op):
-    return '02fb7fa9-8886-4330-9e65-fa7bb1bc5271' in [link.ability.ability_id for link in op.chain if link.finish]
+    async def verify(self, services):
+        for op in await services.get('data_svc').locate('operations',
+                                                        match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+            if self._is_unauth_process_killed(op):
+                return True
+        return False

--- a/app/flags/manual/blue_2a.py
+++ b/app/flags/manual/blue_2a.py
@@ -16,16 +16,15 @@ class ManualBlue2a(Flag):
 
     async def verify(self, services):
         async def is_flag_satisfied():
-            for op in await services.get('data_svc').locate('operations',
-                                                            match=dict(access=BaseWorld.Access.BLUE,
-                                                                       name='Blue Manual')):
+            for op in await services.get('data_svc').locate('operations', match=dict(access=BaseWorld.Access.BLUE,
+                                                                                     name='Blue Manual')):
                 if is_file_detected(op):
                     return True
             return False
 
         def is_file_detected(op):
-            return 'file.malicious.hash' in [f.trait for f in op.all_facts()] and \
-                    op.ran_ability_id('77272c88-ccf5-4225-a3d9-f9e171d1ca5b')
+            return op.ran_ability_id('77272c88-ccf5-4225-a3d9-f9e171d1ca5b') and \
+                   'file.malicious.hash' in [f.trait for f in op.all_facts()]
 
         return await BaseFlag.standard_verify_with_operation(services, self.additional_fields['operation_name'],
                                                              self.additional_fields['adversary_id'],

--- a/app/flags/manual/blue_2a.py
+++ b/app/flags/manual/blue_2a.py
@@ -1,33 +1,33 @@
 from plugins.training.app.base_flag import BaseFlag
+from plugins.training.app.c_flag import Flag
 from app.utility.base_world import BaseWorld
 
 
-name = 'Detect malicious file on system'
-challenge = 'Within a minute of this flag activating, a pretend malicious file will have been written on the ' \
-            'Windows machine. The hash of this file will also have been written into ' \
-            'C:\\Users\\Public\\malicious_files.txt. Run the appropriate detection ability in the \'Blue Manual\' ' \
-            'operation to detect this file hash.'
-extra_info = """"""
+class ManualBlue2a(Flag):
+    name = 'Detect malicious file on system'
+    challenge = 'Within a minute of this flag activating, a pretend malicious file will have been written on the ' \
+                'Windows machine. The hash of this file will also have been written into ' \
+                'C:\\Users\\Public\\malicious_files.txt. Run the appropriate detection ability in the \'Blue Manual\' ' \
+                'operation to detect this file hash.'
+    extra_info = """"""
+    additional_fields = dict(operation_name='training_manual_2',
+                             adversary_id='890508db-9646-4a2d-8d1a-4ea25b3ce02a',
+                             agent_group='cert-win')
 
+    async def verify(self, services):
+        async def is_flag_satisfied():
+            for op in await services.get('data_svc').locate('operations',
+                                                            match=dict(access=BaseWorld.Access.BLUE,
+                                                                       name='Blue Manual')):
+                if is_file_detected(op):
+                    return True
+            return False
 
-operation_name = 'training_manual_2'
-adversary_id = '890508db-9646-4a2d-8d1a-4ea25b3ce02a'
-agent_group = 'cert-win'
+        def is_file_detected(op):
+            return 'file.malicious.hash' in [f.trait for f in op.all_facts()] and \
+                    op.ran_ability_id('77272c88-ccf5-4225-a3d9-f9e171d1ca5b')
 
-
-async def verify(services):
-    return await BaseFlag.standard_verify_with_operation(services, operation_name, adversary_id, agent_group,
-                                                         is_flag_satisfied)
-
-
-async def is_flag_satisfied(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if is_file_detected(op):
-            return True
-    return False
-
-
-def is_file_detected(op):
-    return 'file.malicious.hash' in [f.trait for f in op.all_facts()] and \
-            '77272c88-ccf5-4225-a3d9-f9e171d1ca5b' in [link.ability.ability_id for link in op.chain if link.finish]
+        return await BaseFlag.standard_verify_with_operation(services, self.additional_fields['operation_name'],
+                                                             self.additional_fields['adversary_id'],
+                                                             self.additional_fields['agent_group'],
+                                                             is_flag_satisfied)

--- a/app/flags/manual/blue_2b.py
+++ b/app/flags/manual/blue_2b.py
@@ -1,20 +1,16 @@
 from app.utility.base_world import BaseWorld
+from plugins.training.app.c_flag import Flag
 
 
-name = 'Hunt for malicious file on system'
-challenge = 'Run the appropriate hunt ability in the \'Blue Manual\' operation to find the location of the ' \
-            'malicious file.'
-extra_info = """"""
+class ManualBlue2b(Flag):
+    name = 'Hunt for malicious file on system'
+    challenge = 'Run the appropriate hunt ability in the \'Blue Manual\' operation to find the location of the ' \
+                'malicious file.'
+    extra_info = """"""
 
-
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if is_file_found(op):
-            return True
-    return False
-
-
-def is_file_found(op):
-    return 'host.malicious.file' in [f.trait for f in op.all_facts()] and \
-            'f9b3eff0-e11c-48de-9338-1578b351b14b' in [link.ability.ability_id for link in op.chain if link.finish]
+    async def verify(self, services):
+        for op in await services.get('data_svc').locate('operations',
+                                                        match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+            if self._is_file_found(op):
+                return True
+        return False

--- a/app/flags/manual/blue_2c.py
+++ b/app/flags/manual/blue_2c.py
@@ -2,7 +2,7 @@ from app.utility.base_world import BaseWorld
 from plugins.training.app.c_flag import Flag
 
 
-class ManualBlue1c(Flag):
+class ManualBlue2c(Flag):
     name = 'Delete malicious file on system'
     challenge = 'Run the appropriate response ability in the \'Blue Manual\' operation to delete the previously ' \
                 'found malicious file.'

--- a/app/flags/manual/blue_2c.py
+++ b/app/flags/manual/blue_2c.py
@@ -9,8 +9,8 @@ class ManualBlue2c(Flag):
     extra_info = """"""
 
     async def verify(self, services):
-        def is_file_deleted(op):
-            return op.ran_ability_id('5ec7ae3b-c909-41bb-9b6b-dadec409cd40')
+        def is_file_deleted(operation):
+            return operation.ran_ability_id('5ec7ae3b-c909-41bb-9b6b-dadec409cd40')
 
         for op in await services.get('data_svc').locate('operations',
                                                         match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):

--- a/app/flags/manual/blue_2c.py
+++ b/app/flags/manual/blue_2c.py
@@ -1,19 +1,19 @@
 from app.utility.base_world import BaseWorld
+from plugins.training.app.c_flag import Flag
 
 
-name = 'Delete malicious file on system'
-challenge = 'Run the appropriate response ability in the \'Blue Manual\' operation to delete the previously found ' \
-            'malicious file.'
-extra_info = """"""
+class ManualBlue1c(Flag):
+    name = 'Delete malicious file on system'
+    challenge = 'Run the appropriate response ability in the \'Blue Manual\' operation to delete the previously ' \
+                'found malicious file.'
+    extra_info = """"""
 
+    async def verify(self, services):
+        def is_file_deleted(op):
+            return op.ran_ability_id('5ec7ae3b-c909-41bb-9b6b-dadec409cd40')
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if is_file_deleted(op):
-            return True
-    return False
-
-
-def is_file_deleted(op):
-    return '5ec7ae3b-c909-41bb-9b6b-dadec409cd40' in [link.ability.ability_id for link in op.chain if link.finish]
+        for op in await services.get('data_svc').locate('operations',
+                                                        match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+            if is_file_deleted(op):
+                return True
+        return False

--- a/app/flags/manual/blue_3a.py
+++ b/app/flags/manual/blue_3a.py
@@ -15,16 +15,15 @@ class ManualBlue3a(Flag):
 
     async def verify(self, services):
         async def is_flag_satisfied():
-            for op in await services.get('data_svc').locate('operations',
-                                                            match=dict(access=BaseWorld.Access.BLUE,
-                                                                       name='Blue Manual')):
+            for op in await services.get('data_svc').locate('operations', match=dict(access=BaseWorld.Access.BLUE,
+                                                                                     name='Blue Manual')):
                 if is_url_found(op):
                     return True
             return False
 
         def is_url_found(op):
-            return 'remote.suspicious.url' in [f.trait for f in op.all_facts()] and \
-                    op.ran_ability_id('1226f8ec-e2e5-4311-88e7-378c0e5cc7ce')
+            return op.ran_ability_id('1226f8ec-e2e5-4311-88e7-378c0e5cc7ce') and \
+                   'remote.suspicious.url' in set([f.trait for f in op.all_facts()])
 
         return await BaseFlag.standard_verify_with_operation(services, self.additional_fields['operation_name'],
                                                              self.additional_fields['adversary_id'],

--- a/app/flags/manual/blue_3a.py
+++ b/app/flags/manual/blue_3a.py
@@ -1,32 +1,33 @@
 from plugins.training.app.base_flag import BaseFlag
+from plugins.training.app.c_flag import Flag
 from app.utility.base_world import BaseWorld
 
 
-name = 'Find suspicious URL in mail'
-challenge = 'Within a minute of this flag activating, a pretend phishing email with a malicious URL will have been ' \
-            'sent on the *nix machine. Run the appropriate detection ability in the \'Blue Manual\' operation to ' \
-            'find this URL.'
-extra_info = """"""
+class ManualBlue3a(Flag):
+    name = 'Find suspicious URL in mail'
+    challenge = 'Within a minute of this flag activating, a pretend phishing email with a malicious URL will have been ' \
+                'sent on the *nix machine. Run the appropriate detection ability in the \'Blue Manual\' operation to ' \
+                'find this URL.'
+    extra_info = """"""
+    additional_fields = dict(operation_name='training_manual_3',
+                             adversary_id='2c99958e-36e0-4fab-bcdf-977926a58cd6',
+                             agent_group='cert-nix')
 
+    async def verify(self, services):
+        async def is_flag_satisfied():
+            for op in await services.get('data_svc').locate('operations',
+                                                            match=dict(access=BaseWorld.Access.BLUE,
+                                                                       name='Blue Manual')):
+                if is_url_found(op):
+                    return True
+            return False
 
-operation_name = 'training_manual_3'
-adversary_id = '2c99958e-36e0-4fab-bcdf-977926a58cd6'
-agent_group = 'cert-nix'
+        def is_url_found(op):
+            return 'remote.suspicious.url' in [f.trait for f in op.all_facts()] and \
+                    op.ran_ability_id('1226f8ec-e2e5-4311-88e7-378c0e5cc7ce')
 
+        return await BaseFlag.standard_verify_with_operation(services, self.additional_fields['operation_name'],
+                                                             self.additional_fields['adversary_id'],
+                                                             self.additional_fields['agent_group'],
+                                                             is_flag_satisfied)
 
-async def verify(services):
-    return await BaseFlag.standard_verify_with_operation(services, operation_name, adversary_id, agent_group,
-                                                         is_flag_satisfied)
-
-
-async def is_flag_satisfied(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if is_url_found(op):
-            return True
-    return False
-
-
-def is_url_found(op):
-    return 'remote.suspicious.url' in [f.trait for f in op.all_facts()] and \
-            '1226f8ec-e2e5-4311-88e7-378c0e5cc7ce' in [link.ability.ability_id for link in op.chain if link.finish]

--- a/app/flags/manual/blue_3b.py
+++ b/app/flags/manual/blue_3b.py
@@ -1,30 +1,32 @@
 from plugins.training.app.base_flag import BaseFlag
+from plugins.training.app.c_flag import Flag
 from app.utility.base_world import BaseWorld
 
 
-name = 'Inoculate suspicious URL'
-challenge = 'Run the appropriate response ability in the \'Blue Manual\' operation to inoculate the previously ' \
-            'found URL.'
-extra_info = """"""
+class ManualBlue3b(Flag):
 
+    name = 'Inoculate suspicious URL'
+    challenge = 'Run the appropriate response ability in the \'Blue Manual\' operation to inoculate the previously ' \
+                'found URL.'
+    extra_info = """"""
+    additional_fields = dict(operation_name='training_manual_3_cleanup',
+                             adversary_id='2885d0fe-60a7-469b-9e2e-a46b7be2b4df',
+                             agent_group='cert-nix')
 
-operation_name = 'training_manual_3_cleanup'
-adversary_id = '2885d0fe-60a7-469b-9e2e-a46b7be2b4df'
-agent_group = 'cert-nix'
+    async def verify(self, services):
+        async def is_flag_satisfied():
+            for op in await services.get('data_svc').locate('operations',
+                                                            match=dict(access=BaseWorld.Access.BLUE,
+                                                                       name='Blue Manual')):
+                if is_url_inoculated(op):
+                    return True
+            return False
 
+        def is_url_inoculated(op):
+            return op.ran_ability_id('2ca64acd-dc12-4cc8-b78a-6a182508a50b')
 
-async def verify(services):
-    return await BaseFlag.standard_verify_with_operation(services, operation_name, adversary_id, agent_group,
-                                                         is_flag_satisfied)
+        return await BaseFlag.standard_verify_with_operation(services, self.additional_fields['operation_name'],
+                                                             self.additional_fields['adversary_id'],
+                                                             self.additional_fields['agent_group'],
+                                                             is_flag_satisfied)
 
-
-async def is_flag_satisfied(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if is_url_inoculated(op):
-            return True
-    return False
-
-
-def is_url_inoculated(op):
-    return '2ca64acd-dc12-4cc8-b78a-6a182508a50b' in [link.ability.ability_id for link in op.chain if link.finish]

--- a/app/flags/manual/blue_4a_nix.py
+++ b/app/flags/manual/blue_4a_nix.py
@@ -9,11 +9,11 @@ class ManualBlue4aNix(Flag):
     extra_info = """"""
 
     async def verify(self, services):
-        def cron_jobs_baseline_found():
-            return op.ran_ability_id('ba907d7a-b334-47e7-b652-4e481b5aa534')
+        def cron_jobs_baseline_found(operation):
+            return operation.ran_ability_id('ba907d7a-b334-47e7-b652-4e481b5aa534')
 
         for op in await services.get('data_svc').locate('operations',
                                                         match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-            if cron_jobs_baseline_found():
+            if cron_jobs_baseline_found(op):
                 return True
         return False

--- a/app/flags/manual/blue_4a_nix.py
+++ b/app/flags/manual/blue_4a_nix.py
@@ -1,19 +1,19 @@
 from app.utility.base_world import BaseWorld
+from plugins.training.app.c_flag import Flag
 
 
-name = 'Acquire Cron Jobs Baseline'
-challenge = 'Run the appropriate setup ability in the \'Blue Manual\' operation to acquire a list of currently ' \
-            'existing cron jobs on the *nix machine.'
-extra_info = """"""
+class ManualBlue4aNix(Flag):
+    name = 'Acquire Cron Jobs Baseline'
+    challenge = 'Run the appropriate setup ability in the \'Blue Manual\' operation to acquire a list of currently ' \
+                'existing cron jobs on the *nix machine.'
+    extra_info = """"""
 
+    async def verify(self, services):
+        def cron_jobs_baseline_found():
+            return op.ran_ability_id('ba907d7a-b334-47e7-b652-4e481b5aa534')
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if cron_jobs_baseline_found(op):
-            return True
-    return False
-
-
-def cron_jobs_baseline_found(op):
-    return '' in [link.ability.ability_id for link in op.chain if link.finish]
+        for op in await services.get('data_svc').locate('operations',
+                                                        match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+            if cron_jobs_baseline_found():
+                return True
+        return False

--- a/app/flags/manual/blue_4a_win.py
+++ b/app/flags/manual/blue_4a_win.py
@@ -9,11 +9,11 @@ class ManualBlue4aWin(Flag):
     extra_info = """"""
 
     async def verify(self, services):
-        def is_baseline_acquired():
-            return op.ran_ability_id('a65a62e1-b8c0-4f88-b564-166e7499d560')
+        def is_baseline_acquired(operation):
+            return operation.ran_ability_id('a65a62e1-b8c0-4f88-b564-166e7499d560')
 
         for op in await services.get('data_svc').locate('operations',
                                                         match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-            if is_baseline_acquired():
+            if is_baseline_acquired(op):
                 return True
         return False

--- a/app/flags/manual/blue_4a_win.py
+++ b/app/flags/manual/blue_4a_win.py
@@ -1,19 +1,19 @@
 from app.utility.base_world import BaseWorld
+from plugins.training.app.c_flag import Flag
 
 
-name = 'Acquire Scheduled Tasks Baseline'
-challenge = 'Run the appropriate setup ability in the \'Blue Manual\' operation to acquire a list of currently ' \
-            'existing scheduled tasks on the Windows machine.'
-extra_info = """"""
+class ManualBlue4aWin(Flag):
+    name = 'Acquire Scheduled Tasks Baseline'
+    challenge = 'Run the appropriate setup ability in the \'Blue Manual\' operation to acquire a list of currently ' \
+                'existing scheduled tasks on the Windows machine.'
+    extra_info = """"""
 
+    async def verify(self, services):
+        def is_baseline_acquired():
+            return op.ran_ability_id('a65a62e1-b8c0-4f88-b564-166e7499d560')
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if is_baseline_acquired(op):
-            return True
-    return False
-
-
-def is_baseline_acquired(op):
-    return 'a65a62e1-b8c0-4f88-b564-166e7499d560' in [link.ability.ability_id for link in op.chain if link.finish]
+        for op in await services.get('data_svc').locate('operations',
+                                                        match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+            if is_baseline_acquired():
+                return True
+        return False

--- a/app/flags/manual/blue_4b_nix.py
+++ b/app/flags/manual/blue_4b_nix.py
@@ -1,31 +1,31 @@
 from plugins.training.app.base_flag import BaseFlag
+from plugins.training.app.c_flag import Flag
 from app.utility.base_world import BaseWorld
 
 
-name = 'Find New Unauthorized Cron Job'
-challenge = 'Within a minute of this flag activating, a new cron job will have been installed on the *nix machine. ' \
-            'Run the appropriate detection ability in the \'Blue Manual\' operation to find this cron job.'
-extra_info = """"""
+class ManualBlue4bNix(Flag):
+    name = 'Find New Unauthorized Cron Job'
+    challenge = 'Within a minute of this flag activating, a new cron job will have been installed on the *nix machine. ' \
+                'Run the appropriate detection ability in the \'Blue Manual\' operation to find this cron job.'
+    extra_info = """"""
+    additional_fields = dict(operation_name='training_manual_4a',
+                             adversary_id='9fbc7164-9175-4fc6-bb20-9669dc121df8',
+                             agent_group='cert-nix')
 
+    async def verify(self, services):
+        async def is_flag_satisfied():
+            for op in await services.get('data_svc').locate('operations',
+                                                            match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+                if is_cronjob_found(op):
+                    return True
+            return False
 
-operation_name = 'training_manual_4a'
-adversary_id = '9fbc7164-9175-4fc6-bb20-9669dc121df8'
-agent_group = 'cert-nix'
+        def is_cronjob_found(op):
+            return all(trait in [f.trait for f in op.all_facts()] for trait in ['host.user.name', 'host.new.cronjob']) and \
+                    'ee54384f-cfbc-4228-9dc1-cc5632307afb' in [link.ability.ability_id for link in op.chain if link.finish]
 
+        return await BaseFlag.standard_verify_with_operation(services, self.additional_fields['operation_name'],
+                                                             self.additional_fields['adversary_id'],
+                                                             self.additional_fields['agent_group'],
+                                                             is_flag_satisfied)
 
-async def verify(services):
-    return await BaseFlag.standard_verify_with_operation(services, operation_name, adversary_id, agent_group,
-                                                         is_flag_satisfied)
-
-
-async def is_flag_satisfied(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if is_cronjob_found(op):
-            return True
-    return False
-
-
-def is_cronjob_found(op):
-    return all(trait in [f.trait for f in op.all_facts()] for trait in ['host.user.name', 'host.new.cronjob']) and \
-            'ee54384f-cfbc-4228-9dc1-cc5632307afb' in [link.ability.ability_id for link in op.chain if link.finish]

--- a/app/flags/manual/blue_4b_nix.py
+++ b/app/flags/manual/blue_4b_nix.py
@@ -14,15 +14,17 @@ class ManualBlue4bNix(Flag):
 
     async def verify(self, services):
         async def is_flag_satisfied():
-            for op in await services.get('data_svc').locate('operations',
-                                                            match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+            for op in await services.get('data_svc').locate('operations', match=dict(access=BaseWorld.Access.BLUE,
+                                                                                     name='Blue Manual')):
                 if is_cronjob_found(op):
                     return True
             return False
 
         def is_cronjob_found(op):
-            return all(trait in [f.trait for f in op.all_facts()] for trait in ['host.user.name', 'host.new.cronjob']) and \
-                    op.ran_ability_id('ee54384f-cfbc-4228-9dc1-cc5632307afb')
+            operation_traits = set(f.trait for f in op.all_facts())
+            return op.ran_ability_id('ee54384f-cfbc-4228-9dc1-cc5632307afb') and \
+                'host.user.name' in operation_traits and \
+                'host.new.cronjob' in operation_traits
 
         return await BaseFlag.standard_verify_with_operation(services, self.additional_fields['operation_name'],
                                                              self.additional_fields['adversary_id'],

--- a/app/flags/manual/blue_4b_nix.py
+++ b/app/flags/manual/blue_4b_nix.py
@@ -22,7 +22,7 @@ class ManualBlue4bNix(Flag):
 
         def is_cronjob_found(op):
             return all(trait in [f.trait for f in op.all_facts()] for trait in ['host.user.name', 'host.new.cronjob']) and \
-                    'ee54384f-cfbc-4228-9dc1-cc5632307afb' in [link.ability.ability_id for link in op.chain if link.finish]
+                    op.ran_ability_id('ee54384f-cfbc-4228-9dc1-cc5632307afb')
 
         return await BaseFlag.standard_verify_with_operation(services, self.additional_fields['operation_name'],
                                                              self.additional_fields['adversary_id'],

--- a/app/flags/manual/blue_4b_win.py
+++ b/app/flags/manual/blue_4b_win.py
@@ -15,15 +15,15 @@ class ManualBlue4bWin(Flag):
 
     async def verify(self, services):
         async def is_flag_satisfied():
-            for op in await services.get('data_svc').locate('operations',
-                                                            match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+            for op in await services.get('data_svc').locate('operations', match=dict(access=BaseWorld.Access.BLUE,
+                                                                                     name='Blue Manual')):
                 if is_cronjob_found(op):
                     return True
             return False
 
         def is_cronjob_found(op):
-            return 'host.new.schtask' in [f.trait for f in op.all_facts()] and \
-                    op.ran_ability_id('8bc73098-54d1-4f69-abd5-271e3e2da5df')
+            return op.ran_ability_id('8bc73098-54d1-4f69-abd5-271e3e2da5df') and \
+                   'host.new.schtask' in set(f.trait for f in op.all_facts())
 
         return await BaseFlag.standard_verify_with_operation(services, self.additional_fields['operation_name'],
                                                              self.additional_fields['adversary_id'],

--- a/app/flags/manual/blue_4b_win.py
+++ b/app/flags/manual/blue_4b_win.py
@@ -23,7 +23,7 @@ class ManualBlue4bWin(Flag):
 
         def is_cronjob_found(op):
             return 'host.new.schtask' in [f.trait for f in op.all_facts()] and \
-                    '8bc73098-54d1-4f69-abd5-271e3e2da5df' in [link.ability.ability_id for link in op.chain if link.finish]
+                    op.ran_ability_id('8bc73098-54d1-4f69-abd5-271e3e2da5df')
 
         return await BaseFlag.standard_verify_with_operation(services, self.additional_fields['operation_name'],
                                                              self.additional_fields['adversary_id'],

--- a/app/flags/manual/blue_4b_win.py
+++ b/app/flags/manual/blue_4b_win.py
@@ -1,31 +1,32 @@
 from plugins.training.app.base_flag import BaseFlag
+from plugins.training.app.c_flag import Flag
 from app.utility.base_world import BaseWorld
 
 
-name = 'Find New Unauthorized Scheduled Task'
-challenge = 'Within a minute of this flag activating, a new scheduled task will have been registered on the windows ' \
-            'machine. Run the appropriate detection ability in the \'Blue Manual\' operation to find this cron job.'
-extra_info = """"""
+class ManualBlue4bWin(Flag):
+    name = 'Find New Unauthorized Scheduled Task'
+    challenge = 'Within a minute of this flag activating, a new scheduled task will have been registered on the ' \
+                'windows machine. Run the appropriate detection ability in the \'Blue Manual\' operation to find ' \
+                'this cron job.'
+    extra_info = """"""
+    additional_fields = dict(operation_name='training_manual_4b',
+                             adversary_id='9fbc7164-9175-4fc6-bb20-9669dc121df8',
+                             agent_group='cert-win')
 
+    async def verify(self, services):
+        async def is_flag_satisfied():
+            for op in await services.get('data_svc').locate('operations',
+                                                            match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+                if is_cronjob_found(op):
+                    return True
+            return False
 
-operation_name = 'training_manual_4b'
-adversary_id = '9fbc7164-9175-4fc6-bb20-9669dc121df8'
-agent_group = 'cert-win'
+        def is_cronjob_found(op):
+            return 'host.new.schtask' in [f.trait for f in op.all_facts()] and \
+                    '8bc73098-54d1-4f69-abd5-271e3e2da5df' in [link.ability.ability_id for link in op.chain if link.finish]
 
+        return await BaseFlag.standard_verify_with_operation(services, self.additional_fields['operation_name'],
+                                                             self.additional_fields['adversary_id'],
+                                                             self.additional_fields['agent_group'],
+                                                             is_flag_satisfied)
 
-async def verify(services):
-    return await BaseFlag.standard_verify_with_operation(services, operation_name, adversary_id, agent_group,
-                                                         is_flag_satisfied)
-
-
-async def is_flag_satisfied(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if is_cronjob_found(op):
-            return True
-    return False
-
-
-def is_cronjob_found(op):
-    return 'host.new.schtask' in [f.trait for f in op.all_facts()] and \
-            '8bc73098-54d1-4f69-abd5-271e3e2da5df' in [link.ability.ability_id for link in op.chain if link.finish]

--- a/app/flags/manual/blue_4c_nix.py
+++ b/app/flags/manual/blue_4c_nix.py
@@ -9,11 +9,11 @@ class ManualBlue4cNix(Flag):
     extra_info = """"""
 
     async def verify(self, services):
-        def is_file_deleted():
-            return op.ran_ability_id('32e563bb-ba06-4bcc-b817-fc2c434c0b66')
+        def is_file_deleted(operation):
+            return operation.ran_ability_id('32e563bb-ba06-4bcc-b817-fc2c434c0b66')
 
         for op in await services.get('data_svc').locate('operations',
                                                         match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-            if is_file_deleted():
+            if is_file_deleted(op):
                 return True
         return False

--- a/app/flags/manual/blue_4c_nix.py
+++ b/app/flags/manual/blue_4c_nix.py
@@ -1,19 +1,19 @@
 from app.utility.base_world import BaseWorld
+from plugins.training.app.c_flag import Flag
 
 
-name = 'Delete New Cron Job'
-challenge = 'Run the appropriate response ability in the \'Blue Manual\' operation to delete the previously found ' \
-            'cron job.'
-extra_info = """"""
+class ManualBlue4cNix(Flag):
+    name = 'Delete New Cron Job'
+    challenge = 'Run the appropriate response ability in the \'Blue Manual\' operation to delete the previously ' \
+                'found cron job.'
+    extra_info = """"""
 
+    async def verify(self, services):
+        def is_file_deleted():
+            return op.ran_ability_id('32e563bb-ba06-4bcc-b817-fc2c434c0b66')
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if is_file_deleted(op):
-            return True
-    return False
-
-
-def is_file_deleted(op):
-    return '32e563bb-ba06-4bcc-b817-fc2c434c0b66' in [link.ability.ability_id for link in op.chain if link.finish]
+        for op in await services.get('data_svc').locate('operations',
+                                                        match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+            if is_file_deleted():
+                return True
+        return False

--- a/app/flags/manual/blue_4c_win.py
+++ b/app/flags/manual/blue_4c_win.py
@@ -9,11 +9,11 @@ class ManualBlue4cWin(Flag):
     extra_info = """"""
 
     async def verify(self, services):
-        def is_file_deleted():
-            return op.ran_ability_id('4744d99f-5fea-42a8-8ec4-c228db57caea')
+        def is_file_deleted(operation):
+            return operation.ran_ability_id('4744d99f-5fea-42a8-8ec4-c228db57caea')
 
         for op in await services.get('data_svc').locate('operations',
                                                         match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-            if is_file_deleted():
+            if is_file_deleted(op):
                 return True
         return False

--- a/app/flags/manual/blue_4c_win.py
+++ b/app/flags/manual/blue_4c_win.py
@@ -1,19 +1,19 @@
 from app.utility.base_world import BaseWorld
+from plugins.training.app.c_flag import Flag
 
 
-name = 'Delete New Scheduled Task'
-challenge = 'Run the appropriate response ability in the \'Blue Manual\' operation to delete the previously found ' \
-            'scheduled task.'
-extra_info = """"""
+class ManualBlue4cWin(Flag):
+    name = 'Delete New Scheduled Task'
+    challenge = 'Run the appropriate response ability in the \'Blue Manual\' operation to delete the previously ' \
+                'found scheduled task.'
+    extra_info = """"""
 
+    async def verify(self, services):
+        def is_file_deleted():
+            return op.ran_ability_id('4744d99f-5fea-42a8-8ec4-c228db57caea')
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if is_file_deleted(op):
-            return True
-    return False
-
-
-def is_file_deleted(op):
-    return '4744d99f-5fea-42a8-8ec4-c228db57caea' in [link.ability.ability_id for link in op.chain if link.finish]
+        for op in await services.get('data_svc').locate('operations',
+                                                        match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+            if is_file_deleted():
+                return True
+        return False

--- a/app/flags/manual/blue_5a_nix.py
+++ b/app/flags/manual/blue_5a_nix.py
@@ -9,11 +9,11 @@ class ManualBlue5aNix(Flag):
     extra_info = """"""
 
     async def verify(self, services):
-        def bash_profiles_backed_up():
-            return op.ran_ability_id('622e4bda-e5a8-42bb-93d9-a7b1eebc7e41')
+        def bash_profiles_backed_up(operation):
+            return operation.ran_ability_id('622e4bda-e5a8-42bb-93d9-a7b1eebc7e41')
 
         for op in await services.get('data_svc').locate('operations',
                                                         match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-            if bash_profiles_backed_up():
+            if bash_profiles_backed_up(op):
                 return True
         return False

--- a/app/flags/manual/blue_5a_nix.py
+++ b/app/flags/manual/blue_5a_nix.py
@@ -1,19 +1,19 @@
 from app.utility.base_world import BaseWorld
+from plugins.training.app.c_flag import Flag
 
 
-name = 'Backup Bash Profiles'
-challenge = 'Run the appropriate setup ability in the \'Blue Manual\' operation to backup all the Bash Profiles on ' \
-            'the *nix machine.'
-extra_info = """"""
+class ManualBlue5aNix(Flag):
+    name = 'Backup Bash Profiles'
+    challenge = 'Run the appropriate setup ability in the \'Blue Manual\' operation to backup all the Bash Profiles ' \
+                'on the *nix machine.'
+    extra_info = """"""
 
+    async def verify(self, services):
+        def bash_profiles_backed_up():
+            return op.ran_ability_id('622e4bda-e5a8-42bb-93d9-a7b1eebc7e41')
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if bash_profiles_backed_up(op):
-            return True
-    return False
-
-
-def bash_profiles_backed_up(op):
-    return '622e4bda-e5a8-42bb-93d9-a7b1eebc7e41' in [link.ability.ability_id for link in op.chain if link.finish]
+        for op in await services.get('data_svc').locate('operations',
+                                                        match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+            if bash_profiles_backed_up():
+                return True
+        return False

--- a/app/flags/manual/blue_5a_win.py
+++ b/app/flags/manual/blue_5a_win.py
@@ -1,19 +1,19 @@
 from app.utility.base_world import BaseWorld
+from plugins.training.app.c_flag import Flag
 
 
-name = 'Backup PowerShell Profiles'
-challenge = 'Run the appropriate setup ability in the \'Blue Manual\' operation to backup all the PowerShell ' \
-            'Profiles on the Windows machine.'
-extra_info = """"""
+class ManualBlue5aWin(Flag):
+    name = 'Backup PowerShell Profiles'
+    challenge = 'Run the appropriate setup ability in the \'Blue Manual\' operation to backup all the PowerShell ' \
+                'Profiles on the Windows machine.'
+    extra_info = """"""
 
+    async def verify(self, services):
+        def powershell_profiles_backed_up():
+            return op.ran_ability_id('83d7cf63-e10a-4615-a92e-dce257bf3b9d')
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if powershell_profiles_backed_up(op):
-            return True
-    return False
-
-
-def powershell_profiles_backed_up(op):
-    return '83d7cf63-e10a-4615-a92e-dce257bf3b9d' in [link.ability.ability_id for link in op.chain if link.finish]
+        for op in await services.get('data_svc').locate('operations',
+                                                        match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+            if powershell_profiles_backed_up():
+                return True
+        return False

--- a/app/flags/manual/blue_5a_win.py
+++ b/app/flags/manual/blue_5a_win.py
@@ -9,11 +9,11 @@ class ManualBlue5aWin(Flag):
     extra_info = """"""
 
     async def verify(self, services):
-        def powershell_profiles_backed_up():
-            return op.ran_ability_id('83d7cf63-e10a-4615-a92e-dce257bf3b9d')
+        def powershell_profiles_backed_up(operation):
+            return operation.ran_ability_id('83d7cf63-e10a-4615-a92e-dce257bf3b9d')
 
         for op in await services.get('data_svc').locate('operations',
                                                         match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-            if powershell_profiles_backed_up():
+            if powershell_profiles_backed_up(op):
                 return True
         return False

--- a/app/flags/manual/blue_5b_nix.py
+++ b/app/flags/manual/blue_5b_nix.py
@@ -1,19 +1,19 @@
 from app.utility.base_world import BaseWorld
+from plugins.training.app.c_flag import Flag
 
 
-name = 'Acquire Bash Profile Hashes'
-challenge = 'Run the appropriate setup ability in the \'Blue Manual\' operation to hash all the Bash Profiles on ' \
-            'the *nix machine.'
-extra_info = """"""
+class ManualBlue5bNix(Flag):
+    name = 'Acquire Bash Profile Hashes'
+    challenge = 'Run the appropriate setup ability in the \'Blue Manual\' operation to hash all the Bash Profiles on ' \
+                'the *nix machine.'
+    extra_info = """"""
 
+    async def verify(self, services):
+        def bash_profiles_hashed():
+            return op.ran_ability_id('df9d2b83-b40f-4167-af75-31ddde59af7e')
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if bash_profiles_hashed(op):
-            return True
-    return False
-
-
-def bash_profiles_hashed(op):
-    return 'df9d2b83-b40f-4167-af75-31ddde59af7e' in [link.ability.ability_id for link in op.chain if link.finish]
+        for op in await services.get('data_svc').locate('operations',
+                                                        match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+            if bash_profiles_hashed():
+                return True
+        return False

--- a/app/flags/manual/blue_5b_nix.py
+++ b/app/flags/manual/blue_5b_nix.py
@@ -9,11 +9,11 @@ class ManualBlue5bNix(Flag):
     extra_info = """"""
 
     async def verify(self, services):
-        def bash_profiles_hashed():
-            return op.ran_ability_id('df9d2b83-b40f-4167-af75-31ddde59af7e')
+        def bash_profiles_hashed(operation):
+            return operation.ran_ability_id('df9d2b83-b40f-4167-af75-31ddde59af7e')
 
         for op in await services.get('data_svc').locate('operations',
                                                         match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-            if bash_profiles_hashed():
+            if bash_profiles_hashed(op):
                 return True
         return False

--- a/app/flags/manual/blue_5b_win.py
+++ b/app/flags/manual/blue_5b_win.py
@@ -10,7 +10,7 @@ class ManualBlue5bWin(Flag):
 
     async def verify(self, services):
         def powershell_profiles_hashed():
-            return op.ran_ability.id('90a67a85-e81c-4525-8bae-12a2c5787d9a')
+            return op.ran_ability_id('90a67a85-e81c-4525-8bae-12a2c5787d9a')
 
         for op in await services.get('data_svc').locate('operations',
                                                         match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):

--- a/app/flags/manual/blue_5b_win.py
+++ b/app/flags/manual/blue_5b_win.py
@@ -9,11 +9,11 @@ class ManualBlue5bWin(Flag):
     extra_info = """"""
 
     async def verify(self, services):
-        def powershell_profiles_hashed():
-            return op.ran_ability_id('90a67a85-e81c-4525-8bae-12a2c5787d9a')
+        def powershell_profiles_hashed(operation):
+            return operation.ran_ability_id('90a67a85-e81c-4525-8bae-12a2c5787d9a')
 
         for op in await services.get('data_svc').locate('operations',
                                                         match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-            if powershell_profiles_hashed():
+            if powershell_profiles_hashed(op):
                 return True
         return False

--- a/app/flags/manual/blue_5b_win.py
+++ b/app/flags/manual/blue_5b_win.py
@@ -1,19 +1,19 @@
 from app.utility.base_world import BaseWorld
+from plugins.training.app.c_flag import Flag
 
 
-name = 'Acquire PowerShell Profile Hashes'
-challenge = 'Run the appropriate setup ability in the \'Blue Manual\' operation to hash all the PowerShell ' \
-            'Profiles on the Windows machine.'
-extra_info = """"""
+class ManualBlue5bWin(Flag):
+    name = 'Acquire PowerShell Profile Hashes'
+    challenge = 'Run the appropriate setup ability in the \'Blue Manual\' operation to hash all the PowerShell ' \
+                'Profiles on the Windows machine.'
+    extra_info = """"""
 
+    async def verify(self, services):
+        def powershell_profiles_hashed():
+            return op.ran_ability.id('90a67a85-e81c-4525-8bae-12a2c5787d9a')
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if powershell_profiles_hashed(op):
-            return True
-    return False
-
-
-def powershell_profiles_hashed(op):
-    return '90a67a85-e81c-4525-8bae-12a2c5787d9a' in [link.ability.ability_id for link in op.chain if link.finish]
+        for op in await services.get('data_svc').locate('operations',
+                                                        match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+            if powershell_profiles_hashed():
+                return True
+        return False

--- a/app/flags/manual/blue_5c_nix.py
+++ b/app/flags/manual/blue_5c_nix.py
@@ -15,15 +15,15 @@ class ManualBlue5cNix(Flag):
 
     async def verify(self, services):
         async def is_flag_satisfied():
-            for op in await services.get('data_svc').locate('operations',
-                                                            match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+            for op in await services.get('data_svc').locate('operations', match=dict(access=BaseWorld.Access.BLUE,
+                                                                                     name='Blue Manual')):
                 if is_modified_profile_found(op):
                     return True
             return False
 
         def is_modified_profile_found(op):
-            return 'has_been_modified' in [f.trait for f in op.all_facts()] and \
-                    op.ran_ability_id('930236c2-5397-4868-8c7b-72e294a5a376')
+            return op.ran_ability_id('930236c2-5397-4868-8c7b-72e294a5a376') and \
+                   'has_been_modified' in set(f.trait for f in op.all_facts())
 
         return await BaseFlag.standard_verify_with_operation(services, self.additional_fields['operation_name'],
                                                              self.additional_fields['adversary_id'],

--- a/app/flags/manual/blue_5c_nix.py
+++ b/app/flags/manual/blue_5c_nix.py
@@ -1,32 +1,32 @@
 from plugins.training.app.base_flag import BaseFlag
+from plugins.training.app.c_flag import Flag
 from app.utility.base_world import BaseWorld
 
 
-name = 'Find Changes to Bash Profile'
-challenge = 'Within a minute of this flag activating, the .bashrc file of the user used to deploy the red agent on ' \
-            'the *nix machine will have been modified. Run the appropriate detection ability in the \'Blue Manual\' ' \
-            'operation to find the modified profile.'
-extra_info = """"""
+class ManualBlue5cNix(Flag):
+    name = 'Find Changes to Bash Profile'
+    challenge = 'Within a minute of this flag activating, the .bashrc file of the user used to deploy the red ' \
+                'agent on the *nix machine will have been modified. Run the appropriate detection ability in the ' \
+                '\'Blue Manual\' operation to find the modified profile.'
+    extra_info = """"""
+    additional_fields = dict(operation_name='training_manual_5a',
+                             adversary_id='08619190-9eb5-4f35-97e1-0dafe04e0203',
+                             agent_group='cert-nix')
 
+    async def verify(self, services):
+        async def is_flag_satisfied():
+            for op in await services.get('data_svc').locate('operations',
+                                                            match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+                if is_modified_profile_found(op):
+                    return True
+            return False
 
-operation_name = 'training_manual_5a'
-adversary_id = '08619190-9eb5-4f35-97e1-0dafe04e0203'
-agent_group = 'cert-nix'
+        def is_modified_profile_found(op):
+            return 'has_been_modified' in [f.trait for f in op.all_facts()] and \
+                    op.ran_ability_id('930236c2-5397-4868-8c7b-72e294a5a376')
 
+        return await BaseFlag.standard_verify_with_operation(services, self.additional_fields['operation_name'],
+                                                             self.additional_fields['adversary_id'],
+                                                             self.additional_fields['agent_group'],
+                                                             is_flag_satisfied)
 
-async def verify(services):
-    return await BaseFlag.standard_verify_with_operation(services, operation_name, adversary_id, agent_group,
-                                                         is_flag_satisfied)
-
-
-async def is_flag_satisfied(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if is_modified_profile_found(op):
-            return True
-    return False
-
-
-def is_modified_profile_found(op):
-    return 'has_been_modified' in [f.trait for f in op.all_facts()] and \
-            '930236c2-5397-4868-8c7b-72e294a5a376' in [link.ability.ability_id for link in op.chain if link.finish]

--- a/app/flags/manual/blue_5c_win.py
+++ b/app/flags/manual/blue_5c_win.py
@@ -1,32 +1,32 @@
 from plugins.training.app.base_flag import BaseFlag
+from plugins.training.app.c_flag import Flag
 from app.utility.base_world import BaseWorld
 
 
-name = 'Find Changes to PowerShell Profile'
-challenge = 'Within a minute of this flag activating, the PowerShell Profile pointed at by the $Profile environment ' \
-            'variable on the Windows machine will have been modified. Run the appropriate detection ability in the ' \
-            '\'Blue Manual\' operation to find the modified profile.'
-extra_info = """"""
+class ManualBlue5cWin(Flag):
+    name = 'Find Changes to PowerShell Profile'
+    challenge = 'Within a minute of this flag activating, the PowerShell Profile pointed at by the $Profile ' \
+                'environment variable on the Windows machine will have been modified. Run the appropriate detection ' \
+                'ability in the \'Blue Manual\' operation to find the modified profile.'
+    extra_info = """"""
+    additional_fields = dict(operation_name='training_manual_5b',
+                             adversary_id='08619190-9eb5-4f35-97e1-0dafe04e0203',
+                             agent_group='cert-win')
 
+    async def verify(self, services):
+        async def is_flag_satisfied():
+            for op in await services.get('data_svc').locate('operations',
+                                                            match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+                if is_modified_profile_found(op):
+                    return True
+            return False
 
-operation_name = 'training_manual_5b'
-adversary_id = '08619190-9eb5-4f35-97e1-0dafe04e0203'
-agent_group = 'cert-win'
+        def is_modified_profile_found(op):
+            return 'has_been_modified' in [f.trait for f in op.all_facts()] and \
+                    op.ran_ability_it('930236c2-5397-4868-8c7b-72e294a5a376')
 
+        return await BaseFlag.standard_verify_with_operation(services, self.additional_fields['operation_name'],
+                                                             self.additional_fields['adversary_id'],
+                                                             self.additional_fields['agent_group'],
+                                                             is_flag_satisfied)
 
-async def verify(services):
-    return await BaseFlag.standard_verify_with_operation(services, operation_name, adversary_id, agent_group,
-                                                         is_flag_satisfied)
-
-
-async def is_flag_satisfied(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if is_modified_profile_found(op):
-            return True
-    return False
-
-
-def is_modified_profile_found(op):
-    return 'has_been_modified' in [f.trait for f in op.all_facts()] and \
-            '930236c2-5397-4868-8c7b-72e294a5a376' in [link.ability.ability_id for link in op.chain if link.finish]

--- a/app/flags/manual/blue_5c_win.py
+++ b/app/flags/manual/blue_5c_win.py
@@ -23,7 +23,7 @@ class ManualBlue5cWin(Flag):
 
         def is_modified_profile_found(op):
             return 'has_been_modified' in [f.trait for f in op.all_facts()] and \
-                    op.ran_ability_it('930236c2-5397-4868-8c7b-72e294a5a376')
+                    op.ran_ability_id('930236c2-5397-4868-8c7b-72e294a5a376')
 
         return await BaseFlag.standard_verify_with_operation(services, self.additional_fields['operation_name'],
                                                              self.additional_fields['adversary_id'],

--- a/app/flags/manual/blue_5c_win.py
+++ b/app/flags/manual/blue_5c_win.py
@@ -15,15 +15,15 @@ class ManualBlue5cWin(Flag):
 
     async def verify(self, services):
         async def is_flag_satisfied():
-            for op in await services.get('data_svc').locate('operations',
-                                                            match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+            for op in await services.get('data_svc').locate('operations', match=dict(access=BaseWorld.Access.BLUE,
+                                                                                     name='Blue Manual')):
                 if is_modified_profile_found(op):
                     return True
             return False
 
         def is_modified_profile_found(op):
-            return 'has_been_modified' in [f.trait for f in op.all_facts()] and \
-                    op.ran_ability_id('930236c2-5397-4868-8c7b-72e294a5a376')
+            return op.ran_ability_id('930236c2-5397-4868-8c7b-72e294a5a376') and \
+                   'has_been_modified' in set([f.trait for f in op.all_facts()])
 
         return await BaseFlag.standard_verify_with_operation(services, self.additional_fields['operation_name'],
                                                              self.additional_fields['adversary_id'],

--- a/app/flags/manual/blue_5d_nix.py
+++ b/app/flags/manual/blue_5d_nix.py
@@ -1,19 +1,19 @@
 from app.utility.base_world import BaseWorld
+from plugins.training.app.c_flag import Flag
 
 
-name = 'Restore Modified Bash Profile'
-challenge = 'Run the appropriate response ability in the \'Blue Manual\' operation to restore the previously found ' \
-            'modified Bash Profile with its backup.'
-extra_info = """"""
+class ManualBlue5dNix(Flag):
+    name = 'Restore Modified Bash Profile'
+    challenge = 'Run the appropriate response ability in the \'Blue Manual\' operation to restore the previously ' \
+                'found modified Bash Profile with its backup.'
+    extra_info = """"""
 
+    async def verify(self, services):
+        def is_modified_profile_restored():
+            return op.ran_ability_id('e846973a-767b-4f9c-8b9e-5249cfcd7b97')
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if is_modified_profile_restored(op):
-            return True
-    return False
-
-
-def is_modified_profile_restored(op):
-    return 'e846973a-767b-4f9c-8b9e-5249cfcd7b97' in [link.ability.ability_id for link in op.chain if link.finish]
+        for op in await services.get('data_svc').locate('operations',
+                                                        match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+            if is_modified_profile_restored():
+                return True
+        return False

--- a/app/flags/manual/blue_5d_nix.py
+++ b/app/flags/manual/blue_5d_nix.py
@@ -9,11 +9,11 @@ class ManualBlue5dNix(Flag):
     extra_info = """"""
 
     async def verify(self, services):
-        def is_modified_profile_restored():
-            return op.ran_ability_id('e846973a-767b-4f9c-8b9e-5249cfcd7b97')
+        def is_modified_profile_restored(operation):
+            return operation.ran_ability_id('e846973a-767b-4f9c-8b9e-5249cfcd7b97')
 
         for op in await services.get('data_svc').locate('operations',
                                                         match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-            if is_modified_profile_restored():
+            if is_modified_profile_restored(op):
                 return True
         return False

--- a/app/flags/manual/blue_5d_win.py
+++ b/app/flags/manual/blue_5d_win.py
@@ -9,11 +9,11 @@ class ManualBlue5dWin(Flag):
     extra_info = """"""
 
     async def verify(self, services):
-        def is_modified_profile_restored():
-            return op.ran_ability_id('e846973a-767b-4f9c-8b9e-5249cfcd7b97')
+        def is_modified_profile_restored(operation):
+            return operation.ran_ability_id('e846973a-767b-4f9c-8b9e-5249cfcd7b97')
 
         for op in await services.get('data_svc').locate('operations',
                                                         match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-            if is_modified_profile_restored():
+            if is_modified_profile_restored(op):
                 return True
         return False

--- a/app/flags/manual/blue_5d_win.py
+++ b/app/flags/manual/blue_5d_win.py
@@ -1,19 +1,19 @@
 from app.utility.base_world import BaseWorld
+from plugins.training.app.c_flag import Flag
 
 
-name = 'Restore Modified PowerShell Profile'
-challenge = 'Run the appropriate response ability in the \'Blue Manual\' operation to restore the previously found ' \
-            'modified PowerShell Profile with its backup.'
-extra_info = """"""
+class ManualBlue5dWin(Flag):
+    name = 'Restore Modified PowerShell Profile'
+    challenge = 'Run the appropriate response ability in the \'Blue Manual\' operation to restore the previously ' \
+                'found modified PowerShell Profile with its backup.'
+    extra_info = """"""
 
+    async def verify(self, services):
+        def is_modified_profile_restored():
+            return op.ran_ability_id('e846973a-767b-4f9c-8b9e-5249cfcd7b97')
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations',
-                                                    match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
-        if is_modified_profile_restored(op):
-            return True
-    return False
-
-
-def is_modified_profile_restored(op):
-    return 'e846973a-767b-4f9c-8b9e-5249cfcd7b97' in [link.ability.ability_id for link in op.chain if link.finish]
+        for op in await services.get('data_svc').locate('operations',
+                                                        match=dict(access=BaseWorld.Access.BLUE, name='Blue Manual')):
+            if is_modified_profile_restored():
+                return True
+        return False

--- a/app/flags/operations/flag_0.py
+++ b/app/flags/operations/flag_0.py
@@ -1,12 +1,15 @@
-name = 'Basic operation'
-challenge = 'Run a new operation, using the Hunter profile and select any group of agents'
-extra_info = """An autonomous operation is where an adversary pre-configures their attack and let's their agent and C2 operate
-without their interference. From a red-team perspective, this is an invaluable way to run repeatable adversary
-emulation exercises, ensuring that each one is identical to the last."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations'):
-        if op.finish and op.adversary.adversary_id == 'de07f52d-9928-4071-9142-cb1d3bd851e8':
-            return True
-    return False
+class OperationsFlag0(Flag):
+    name = 'Basic operation'
+    challenge = 'Run a new operation, using the Hunter profile and select any group of agents'
+    extra_info = """An autonomous operation is where an adversary pre-configures their attack and let's their agent 
+    and C2 operate without their interference. From a red-team perspective, this is an invaluable way to run 
+    repeatable adversary emulation exercises, ensuring that each one is identical to the last."""
+
+    async def verify(self, services):
+        for op in await services.get('data_svc').locate('operations'):
+            if op.finish and op.adversary.adversary_id == 'de07f52d-9928-4071-9142-cb1d3bd851e8':
+                return True
+        return False

--- a/app/flags/operations/flag_1.py
+++ b/app/flags/operations/flag_1.py
@@ -1,15 +1,18 @@
-name = 'Base64 operation'
-challenge = 'Run a new operation, using any adversary profile - except Hunter - and change the jitter to 10/20 ' \
-              'and the obfuscation to base64. At least 5 abilities should execute.'
-extra_info = """Just as it is important to use random beacon intervals, adding a random sleep time (jitter) between each command an
-agent runs is equally important for staying undetected. Another way to stay undetected is to obfuscate your commands.
-Defenders will often write monitors to detect specific keywords used on a host. If an adversary obfuscates their
-commands, they can bypass this sort of detection tactic."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations'):
-        if op.finish and op.adversary.adversary_id != 'de07f52d-9928-4071-9142-cb1d3bd851e8' \
-                and op.obfuscator == 'base64' and op.jitter == '10/20' and len(op.chain) >= 5:
-            return True
-    return False
+class OperationsFlag1(Flag):
+    name = 'Base64 operation'
+    challenge = 'Run a new operation, using any adversary profile - except Hunter - and change the jitter to 10/20 ' \
+                'and the obfuscation to base64. At least 5 abilities should execute.'
+    extra_info = """Just as it is important to use random beacon intervals, adding a random sleep time (jitter) between 
+    each command an agent runs is equally important for staying undetected. Another way to stay undetected is to 
+    obfuscate your commands. Defenders will often write monitors to detect specific keywords used on a host. If an 
+    adversary obfuscates their commands, they can bypass this sort of detection tactic."""
+
+    async def verify(self, services):
+        for op in await services.get('data_svc').locate('operations'):
+            if op.finish and op.adversary.adversary_id != 'de07f52d-9928-4071-9142-cb1d3bd851e8' \
+                    and op.obfuscator == 'base64' and op.jitter == '10/20' and len(op.chain) >= 5:
+                return True
+        return False

--- a/app/flags/operations/flag_2.py
+++ b/app/flags/operations/flag_2.py
@@ -1,12 +1,15 @@
-name = 'Manual operation'
-challenge = 'Run a new operation, using any adversary profile - except Hunter - and run the operation requiring ' \
-              'manual approval. Approve and discard links as desired.'
-extra_info = """Sometimes, in an adversary emulation exercise, you may want to approve every command before it is tasked to an agent.
-This allows you to ensure it doesn't do anything you don't want it to."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations'):
-        if op.finish and op.adversary.adversary_id != 'de07f52d-9928-4071-9142-cb1d3bd851e8' and not op.autonomous:
-            return True
-    return False
+class OperationsFlag2(Flag):
+    name = 'Manual operation'
+    challenge = 'Run a new operation, using any adversary profile - except Hunter - and run the operation requiring ' \
+                'manual approval. Approve and discard links as desired.'
+    extra_info = """Sometimes, in an adversary emulation exercise, you may want to approve every command before it is 
+    tasked to an agent. This allows you to ensure it doesn't do anything you don't want it to."""
+
+    async def verify(self, services):
+        for op in await services.get('data_svc').locate('operations'):
+            if op.finish and op.adversary.adversary_id != 'de07f52d-9928-4071-9142-cb1d3bd851e8' and not op.autonomous:
+                return True
+        return False

--- a/app/flags/operations/flag_3.py
+++ b/app/flags/operations/flag_3.py
@@ -1,12 +1,16 @@
-name = 'Empty operation'
-challenge = 'Run a new operation, this time not selecting any profiles or groups. Add at least 5 potential links ' \
-              'to the operation.'
-extra_info = """When you run an autonomous adversary emulation exercise, the operation can only run the tasks it is pre-configured
-to run. Using potential links, you can "toss in" any additional TTPs into a live, autonomous operation."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations'):
-        if op.finish and op.adversary.adversary_id == 'ad-hoc' and len(op.chain) >= 5 and not op.group:
-            return True
-    return False
+class OperationsFlag3(Flag):
+    name = 'Empty operation'
+    challenge = 'Run a new operation, this time not selecting any profiles or groups. Add at least 5 potential links ' \
+                'to the operation.'
+    extra_info = """When you run an autonomous adversary emulation exercise, the operation can only run the tasks it 
+    is pre-configured to run. Using potential links, you can "toss in" any additional TTPs into a live, autonomous 
+    operation."""
+
+    async def verify(self, services):
+        for op in await services.get('data_svc').locate('operations'):
+            if op.finish and op.adversary.adversary_id == 'ad-hoc' and len(op.chain) >= 5 and not op.group:
+                return True
+        return False

--- a/app/flags/plugins/atomic/flag_0.py
+++ b/app/flags/plugins/atomic/flag_0.py
@@ -1,10 +1,14 @@
-name = 'Atomic plugin'
-challenge = 'As a red user, enable the Atomic plugin and verify that new abilities have been added to the database'
-extra_info = """There are lots of sources for TTPs on the Internet, and more are added daily. These TTPs can be in any format and in
-any language. It is possible, and often trivial, to import them into CALDERA for use in operations."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    for _ in await services.get('data_svc').locate('plugins', dict(enabled=True, name='atomic')):
-        return True
-    return False
+class PluginsAtomicFlag0(Flag):
+    name = 'Atomic plugin'
+    challenge = 'As a red user, enable the Atomic plugin and verify that new abilities have been added to the database'
+    extra_info = """There are lots of sources for TTPs on the Internet, and more are added daily. These TTPs can be in 
+    any format and in any language. It is possible, and often trivial, to import them into CALDERA for use in 
+    operations."""
+
+    async def verify(self, services):
+        for _ in await services.get('data_svc').locate('plugins', dict(enabled=True, name='atomic')):
+            return True
+        return False

--- a/app/flags/plugins/compass/flag_0.py
+++ b/app/flags/plugins/compass/flag_0.py
@@ -1,11 +1,14 @@
-name = 'Compass plugin'
-challenge = 'In the Compass plugin, create a new adversary'
-extra_info = """Before an adversary emulation exercise, it may be helpful to display the adversary you plan on running on the
-ATT&CK matrix. The matrix will highlight each TTP contained in the adversary profile."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    for a in await services.get('data_svc').locate('adversaries'):
-        if 'compass' in a.description:
-            return True
-    return False
+class PluginsCompassFlag0(Flag):
+    name = 'Compass plugin'
+    challenge = 'In the Compass plugin, create a new adversary'
+    extra_info = """Before an adversary emulation exercise, it may be helpful to display the adversary you plan on 
+    running on the ATT&CK matrix. The matrix will highlight each TTP contained in the adversary profile."""
+
+    async def verify(self, services):
+        for a in await services.get('data_svc').locate('adversaries'):
+            if 'compass' in a.description:
+                return True
+        return False

--- a/app/flags/plugins/gameboard/flag_0.py
+++ b/app/flags/plugins/gameboard/flag_0.py
@@ -1,16 +1,19 @@
 from app.utility.base_world import BaseWorld
-
-name = 'GameBoard plugin'
-challenge = 'Run a red-blue exercise. Create a Red operation named exactly \'Gameboard - Red\', and then run a Blue ' \
-            'operation against it named exactly \'Gameboard - Blue\'. The results of this exercise can be seen in ' \
-            'the Gameboard plugin modal.'
-extra_info = """Purple-teaming is the process of running a red-team engagement in conjunction with the blue-team. It
- is often fruitful to provide some - but not all - of the details between the red and blue teams. This allows both sides
- to train against each other."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    red = await services.get('data_svc').locate('operations', dict(access=BaseWorld.Access.RED, name='Gameboard - Red'))
-    blue = await services.get('data_svc').locate('operations', dict(access=BaseWorld.Access.BLUE,
-                                                                    name='Gameboard - Blue'))
-    return all(red + blue)
+class PluginsGameboardFlag0(Flag):
+    name = 'GameBoard plugin'
+    challenge = 'Run a red-blue exercise. Create a Red operation named exactly \'Gameboard - Red\', and then run a ' \
+                'Blue operation against it named exactly \'Gameboard - Blue\'. The results of this exercise can be ' \
+                'seen in the Gameboard plugin modal.'
+    extra_info = """Purple-teaming is the process of running a red-team engagement in conjunction with the blue-team. It
+     is often fruitful to provide some - but not all - of the details between the red and blue teams. This allows both 
+     sides to train against each other."""
+
+    async def verify(self, services):
+        red = await services.get('data_svc').locate('operations', dict(access=BaseWorld.Access.RED,
+                                                                       name='Gameboard - Red'))
+        blue = await services.get('data_svc').locate('operations', dict(access=BaseWorld.Access.BLUE,
+                                                                        name='Gameboard - Blue'))
+        return all(red + blue)

--- a/app/flags/plugins/manx/flag_0.py
+++ b/app/flags/plugins/manx/flag_0.py
@@ -1,22 +1,25 @@
-name = 'Manx plugin'
-challenge = 'Start a new Manx agent on your localhost. Then send at least 2 commands to it through the reverse-shell ' \
-              'session. Then run a normal operation against the agent using the Hunter profile.'
-extra_info = """One of the most common activities a red-team operator will attempt to do is gain a reverse-shell on a compromised
-host. This type of shell is a persistent (usually via TCP) connection which gives the operator a terminal experience
-that is as-if they are sitting behind the keyboard on the remote host."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    check1, check2 = False, False
-    for agent in await services.get('data_svc').locate('agents', dict(contact='tcp')):
-        history = [entry for entry in services.get('contact_svc').report['websocket'] if entry['paw'] == agent.paw]
-        if len(history) > 1:
-            check1 = True
-        for op in await services.get('data_svc').locate('operations'):
-            if op.adversary.adversary_id != 'de07f52d-9928-4071-9142-cb1d3bd851e8':
-                continue
-            for op_agent in op.agents:
-                if op_agent.paw == agent.paw and op.finish:
-                    check2 = True
-                    break
-    return all([check1, check2])
+class PluginsManxFlag0(Flag):
+    name = 'Manx plugin'
+    challenge = 'Start a new Manx agent on your localhost. Then send at least 2 commands to it through the ' \
+                'reverse-shell session. Then run a normal operation against the agent using the Hunter profile.'
+    extra_info = """One of the most common activities a red-team operator will attempt to do is gain a reverse-shell 
+    on a compromised host. This type of shell is a persistent (usually via TCP) connection which gives the operator a 
+    terminal experience that is as-if they are sitting behind the keyboard on the remote host."""
+
+    async def verify(self, services):
+        check1, check2 = False, False
+        for agent in await services.get('data_svc').locate('agents', dict(contact='tcp')):
+            history = [entry for entry in services.get('contact_svc').report['websocket'] if entry['paw'] == agent.paw]
+            if len(history) > 1:
+                check1 = True
+            for op in await services.get('data_svc').locate('operations'):
+                if op.adversary.adversary_id != 'de07f52d-9928-4071-9142-cb1d3bd851e8':
+                    continue
+                for op_agent in op.agents:
+                    if op_agent.paw == agent.paw and op.finish:
+                        check2 = True
+                        break
+        return all([check1, check2])

--- a/app/flags/plugins/manx/flag_1.py
+++ b/app/flags/plugins/manx/flag_1.py
@@ -1,12 +1,15 @@
-name = 'Manx UDP'
-challenge = 'Start a new Manx agent in UDP mode'
-extra_info = """If an adversary is having trouble getting an agent to connect outbound over popular protocols, like HTTP or TCP, they
-will often fallback to UDP. Because DNS goes over UDP, this protocol is usually more accessible than others. In
-addition, lazy system administrators may forget to add firewall rules on UDP ports whereas TCP is the default in most
-firewall tools."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    for _ in await services.get('data_svc').locate('agents', dict(contact='udp')):
-        return True
-    return False
+class PluginsManxFlag1(Flag):
+    name = 'Manx UDP'
+    challenge = 'Start a new Manx agent in UDP mode'
+    extra_info = """If an adversary is having trouble getting an agent to connect outbound over popular protocols, like 
+    HTTP or TCP, they will often fallback to UDP. Because DNS goes over UDP, this protocol is usually more accessible 
+    than others. In addition, lazy system administrators may forget to add firewall rules on UDP ports whereas TCP is 
+    the default in most firewall tools."""
+
+    async def verify(self, services):
+        for _ in await services.get('data_svc').locate('agents', dict(contact='udp')):
+            return True
+        return False

--- a/app/flags/plugins/mock/flag_0.py
+++ b/app/flags/plugins/mock/flag_0.py
@@ -1,12 +1,15 @@
-name = 'Mock plugin'
-challenge = 'Enable the mock plugin, then run an operation against the simulated group, using the Hunter profile.'
-extra_info = """Testing out attacks ahead of time is the only way to ensure a high chance of success. This can be cumbersome because
-you may need a full test lab of varying operating systems to do a full test. Simulating the responses of various TTPs
-is a good way to quickly get a feel for how your attack may play out."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations', dict(group='simulation')):
-        if op.finish and op.adversary.adversary_id == 'de07f52d-9928-4071-9142-cb1d3bd851e8':
-            return True
-    return False
+class PluginsMockFlag0(Flag):
+    name = 'Mock plugin'
+    challenge = 'Enable the mock plugin, then run an operation against the simulated group, using the Hunter profile.'
+    extra_info = """Testing out attacks ahead of time is the only way to ensure a high chance of success. This can be 
+    cumbersome because you may need a full test lab of varying operating systems to do a full test. Simulating the 
+    responses of various TTPs is a good way to quickly get a feel for how your attack may play out."""
+
+    async def verify(self, services):
+        for op in await services.get('data_svc').locate('operations', dict(group='simulation')):
+            if op.finish and op.adversary.adversary_id == 'de07f52d-9928-4071-9142-cb1d3bd851e8':
+                return True
+        return False

--- a/app/flags/plugins/response/flag_0.py
+++ b/app/flags/plugins/response/flag_0.py
@@ -1,10 +1,13 @@
-name = 'Blue agent'
-challenge = 'Log in as a blue user and deploy a new blue agent. The agent should successfully beacon back to this server instance. ' \
-            'Blue agents should be run with elevated privileges.'
-extra_info = """Most Endpoint Detection and Response products use agents that are installed on the endpoints that need
-to be protected. Sandcat can function as Caldera's Blue agent too."""
+from plugins.training.app.c_flag import Flag
 
 
-async def verify(services):
-    agents = await services.get('data_svc').locate('agents')
-    return True if any(agent.group == 'blue' for agent in agents) else False
+class PluginsResponseFlag0(Flag):
+    name = 'Blue agent'
+    challenge = 'Log in as a blue user and deploy a new blue agent. The agent should successfully beacon back to ' \
+                'this server instance. Blue agents should be run with elevated privileges.'
+    extra_info = """Most Endpoint Detection and Response products use agents that are installed on the endpoints that 
+    need to be protected. Sandcat can function as Caldera's Blue agent too."""
+
+    async def verify(self, services):
+        agents = await services.get('data_svc').locate('agents')
+        return True if any(agent.group == 'blue' for agent in agents) else False

--- a/app/flags/plugins/response/flag_1.py
+++ b/app/flags/plugins/response/flag_1.py
@@ -1,30 +1,21 @@
 from app.utility.base_world import BaseWorld
+from plugins.training.app.c_flag import Flag
 
 
-name = 'Blue operation'
-challenge = 'Using the machine with the blue agent, connect to a listener on another machine listening on TCP ' \
-            'port 7011. This can be done using Netcat on *nix machines, or TcpClient on Windows machines.' \
-            'Then, run a blue operation using the blue agent group, the \'Incident responder\' defender, the batch ' \
-            'planner and the response fact source.'
-extra_info = 'EDR agents are intended to run at all times while the endpoint is running. To simulate this, ' \
-             'agents can be registered on endpoints to automatically run when the endpoint is booted. Defenders ' \
-             'can also be instructed to run continuously through the use of Repeatable abilities.'
+class PluginsResponseFlag1(Flag):
+    name = 'Blue operation'
+    challenge = 'Using the machine with the blue agent, connect to a listener on another machine listening on TCP ' \
+                'port 7011. This can be done using Netcat on *nix machines, or TcpClient on Windows machines.' \
+                'Then, run a blue operation using the blue agent group, the \'Incident responder\' defender, the ' \
+                'batch planner and the response fact source.'
+    extra_info = 'EDR agents are intended to run at all times while the endpoint is running. To simulate this, ' \
+                 'agents can be registered on endpoints to automatically run when the endpoint is booted. Defenders ' \
+                 'can also be instructed to run continuously through the use of Repeatable abilities.'
 
-
-async def verify(services):
-    for op in await services.get('data_svc').locate('operations', dict(access=BaseWorld.Access.BLUE)):
-        if len(op.agents) and op.group == 'blue' and \
-                op.adversary.adversary_id == '7e422753-ad7a-4401-bc8b-b12a28e69c25':
-            if is_unauth_process_killed(op):
-                return True
-    return False
-
-
-def is_unauth_process_detected(operation):
-    facts = operation.all_facts()
-    return True if any(fact.trait == 'host.pid.unauthorized' for fact in facts) else False
-
-
-def is_unauth_process_killed(operation):
-    return True if any(link.ability.ability_id == '02fb7fa9-8886-4330-9e65-fa7bb1bc5271' for link in operation.chain) \
-        else False
+    async def verify(self, services):
+        for op in await services.get('data_svc').locate('operations', dict(access=BaseWorld.Access.BLUE)):
+            if len(op.agents) and op.group == 'blue' and \
+                    op.adversary.adversary_id == '7e422753-ad7a-4401-bc8b-b12a28e69c25':
+                if self._is_unauth_process_killed(op):
+                    return True
+        return False

--- a/app/training_api.py
+++ b/app/training_api.py
@@ -38,7 +38,7 @@ class TrainingApi(BaseService):
                         if answer:
                             flag.completed = flag.verify(answer)
                     else:
-                        flag.completed = await flag.verify(flag, self.services)
+                        flag.completed = await flag.verify(self.services)
                     if not hasattr(cert, 'cert_type'):
                         break
             except Exception as e:

--- a/app/training_api.py
+++ b/app/training_api.py
@@ -33,12 +33,12 @@ class TrainingApi(BaseService):
             try:
                 if not flag.completed:
                     flag.activate()
-                    if hasattr(flag, 'flag_type'):
+                    if hasattr(flag, 'answer'):
                         answer = answers.get(str(flag.number), None)
                         if answer:
                             flag.completed = flag.verify(answer)
                     else:
-                        flag.completed = await flag.verify(self.services)
+                        flag.completed = await flag.verify(flag, self.services)
                     if not hasattr(cert, 'cert_type'):
                         break
             except Exception as e:

--- a/data/certifications/8da8f0b3-194a-4eed-95b0-43c1f1b64091.yml
+++ b/data/certifications/8da8f0b3-194a-4eed-95b0-43c1f1b64091.yml
@@ -2,31 +2,27 @@ id: 8da8f0b3-194a-4eed-95b0-43c1f1b64091
 name: Blue Certificate
 badges:
   agents:
-    flags:
-      - flags.agents.blue_0
-      - flags.agents.blue_1
-      - flags.agents.blue_2
-      - flags.agents.blue_3
+    - flags.agents.blue_0:AgentsBlue0
+    - flags.agents.blue_1:AgentsBlue1
+    - flags.agents.blue_2:AgentsBlue2
+    - flags.agents.blue_3:AgentsBlue3
   autonomous:
-    flags:
-      - flags.autonomous.blue_0
-      - flags.autonomous.blue_1
-      - flags.autonomous.blue_2
-      - flags.autonomous.blue_3
+    - flags.autonomous.blue_0:AutonomousBlue0
+    - flags.autonomous.blue_1:AutonomousBlue1
+    - flags.autonomous.blue_2:AutonomousBlue2
+    - flags.autonomous.blue_3:AutonomousBlue3
   manual:
-    flags:
-      - flags.manual.blue_0
-      - flags.manual.blue_2a
-      - flags.manual.blue_2b
-      - flags.manual.blue_2c
-      - flags.manual.blue_5a_win
-      - flags.manual.blue_5b_win
-      - flags.manual.blue_5c_win
-      - flags.manual.blue_5d_win
+    - flags.manual.blue_0:ManualBlue0
+    - flags.manual.blue_2a:ManualBlue2a
+    - flags.manual.blue_2b:ManualBlue2b
+    - flags.manual.blue_2c:ManualBlue2c
+    - flags.manual.blue_5a_win:ManualBlue5aWin
+    - flags.manual.blue_5b_win:ManualBlue5bWin
+    - flags.manual.blue_5c_win:ManualBlue5cWin
+    - flags.manual.blue_5d_win:ManualBlue5dWin
   attack:
-    flags:
-      - flags.attack.blue_0
-      - flags.attack.blue_1
-      - flags.attack.blue_2
-      - flags.attack.blue_3
-      - flags.attack.blue_4
+    - flags.attack.blue_0:AttackBlue0
+    - flags.attack.blue_1:AttackBlue1
+    - flags.attack.blue_2:AttackBlue2
+    - flags.attack.blue_3:AttackBlue3
+    - flags.attack.blue_4:AttackBlue4

--- a/data/certifications/8da8f0b3-194a-4eed-95b0-43c1f1b64091.yml
+++ b/data/certifications/8da8f0b3-194a-4eed-95b0-43c1f1b64091.yml
@@ -2,27 +2,27 @@ id: 8da8f0b3-194a-4eed-95b0-43c1f1b64091
 name: Blue Certificate
 badges:
   agents:
-    - flags.agents.blue_0:AgentsBlue0
-    - flags.agents.blue_1:AgentsBlue1
-    - flags.agents.blue_2:AgentsBlue2
-    - flags.agents.blue_3:AgentsBlue3
+    - flags.agents.blue_0.AgentsBlue0
+    - flags.agents.blue_1.AgentsBlue1
+    - flags.agents.blue_2.AgentsBlue2
+    - flags.agents.blue_3.AgentsBlue3
   autonomous:
-    - flags.autonomous.blue_0:AutonomousBlue0
-    - flags.autonomous.blue_1:AutonomousBlue1
-    - flags.autonomous.blue_2:AutonomousBlue2
-    - flags.autonomous.blue_3:AutonomousBlue3
+    - flags.autonomous.blue_0.AutonomousBlue0
+    - flags.autonomous.blue_1.AutonomousBlue1
+    - flags.autonomous.blue_2.AutonomousBlue2
+    - flags.autonomous.blue_3.AutonomousBlue3
   manual:
-    - flags.manual.blue_0:ManualBlue0
-    - flags.manual.blue_2a:ManualBlue2a
-    - flags.manual.blue_2b:ManualBlue2b
-    - flags.manual.blue_2c:ManualBlue2c
-    - flags.manual.blue_5a_win:ManualBlue5aWin
-    - flags.manual.blue_5b_win:ManualBlue5bWin
-    - flags.manual.blue_5c_win:ManualBlue5cWin
-    - flags.manual.blue_5d_win:ManualBlue5dWin
+    - flags.manual.blue_0.ManualBlue0
+    - flags.manual.blue_2a.ManualBlue2a
+    - flags.manual.blue_2b.ManualBlue2b
+    - flags.manual.blue_2c.ManualBlue2c
+    - flags.manual.blue_5a_win.ManualBlue5aWin
+    - flags.manual.blue_5b_win.ManualBlue5bWin
+    - flags.manual.blue_5c_win.ManualBlue5cWin
+    - flags.manual.blue_5d_win.ManualBlue5dWin
   attack:
-    - flags.attack.blue_0:AttackBlue0
-    - flags.attack.blue_1:AttackBlue1
-    - flags.attack.blue_2:AttackBlue2
-    - flags.attack.blue_3:AttackBlue3
-    - flags.attack.blue_4:AttackBlue4
+    - flags.attack.blue_0.AttackBlue0
+    - flags.attack.blue_1.AttackBlue1
+    - flags.attack.blue_2.AttackBlue2
+    - flags.attack.blue_3.AttackBlue3
+    - flags.attack.blue_4.AttackBlue4

--- a/data/certifications/9cd5f3a0-765d-45bc-85c2-bc76d4282599.yml
+++ b/data/certifications/9cd5f3a0-765d-45bc-85c2-bc76d4282599.yml
@@ -3,38 +3,38 @@ name: User Certificate
 description: "Basic user certificate."
 badges:
   agents:
-    - flags.agents.flag_0:AgentsFlag0
-    - flags.agents.flag_1:AgentsFlag1
-    - flags.agents.flag_2:AgentsFlag2
-    - flags.agents.flag_3:AgentsFlag3
-    - flags.agents.flag_4:AgentsFlag4
-    - flags.agents.flag_5:AgentsFlag5
-    - flags.agents.flag_6:AgentsFlag6
-    - flags.agents.flag_7:AgentsFlag7
+    - flags.agents.flag_0.AgentsFlag0
+    - flags.agents.flag_1.AgentsFlag1
+    - flags.agents.flag_2.AgentsFlag2
+    - flags.agents.flag_3.AgentsFlag3
+    - flags.agents.flag_4.AgentsFlag4
+    - flags.agents.flag_5.AgentsFlag5
+    - flags.agents.flag_6.AgentsFlag6
+    - flags.agents.flag_7.AgentsFlag7
   adversaries:
-    - flags.adversaries.flag_0:AdversariesFlag0
-    - flags.adversaries.flag_1:AdversariesFlag1
-    - flags.adversaries.flag_2:AdversariesFlag2
+    - flags.adversaries.flag_0.AdversariesFlag0
+    - flags.adversaries.flag_1.AdversariesFlag1
+    - flags.adversaries.flag_2.AdversariesFlag2
   operations:
-    - flags.operations.flag_0:OperationsFlag0
-    - flags.operations.flag_1:OperationsFlag1
-    - flags.operations.flag_2:OperationsFlag2
-    - flags.operations.flag_3:OperationsFlag3
+    - flags.operations.flag_0.OperationsFlag0
+    - flags.operations.flag_1.OperationsFlag1
+    - flags.operations.flag_2.OperationsFlag2
+    - flags.operations.flag_3.OperationsFlag3
   advanced:
-    - flags.advanced.flag_0:AdvancedFlag0
-    - flags.advanced.flag_1:AdvancedFlag1
-    - flags.advanced.flag_2:AdvancedFlag2
+    - flags.advanced.flag_0.AdvancedFlag0
+    - flags.advanced.flag_1.AdvancedFlag1
+    - flags.advanced.flag_2.AdvancedFlag2
   manx:
-    - flags.plugins.manx.flag_0:PluginsManxFlag0
-    - flags.plugins.manx.flag_1:PluginsManxFlag1
+    - flags.plugins.manx.flag_0.PluginsManxFlag0
+    - flags.plugins.manx.flag_1.PluginsManxFlag1
   mock:
-    - flags.plugins.mock.flag_0:PluginsMockFlag0
+    - flags.plugins.mock.flag_0.PluginsMockFlag0
   compass:
-    - flags.plugins.compass.flag_0:PluginsCompassFlag0
+    - flags.plugins.compass.flag_0.PluginsCompassFlag0
   response:
-    - flags.plugins.response.flag_0:PluginsResponseFlag0
-    - flags.plugins.response.flag_1:PluginsResponseFlag1
+    - flags.plugins.response.flag_0.PluginsResponseFlag0
+    - flags.plugins.response.flag_1.PluginsResponseFlag1
   gameboard:
-    - flags.plugins.gameboard.flag_0:PluginsGameboardFlag0
+    - flags.plugins.gameboard.flag_0.PluginsGameboardFlag0
   atomic:
-    - flags.plugins.atomic.flag_0:PluginsAtomicFlag0
+    - flags.plugins.atomic.flag_0.PluginsAtomicFlag0

--- a/data/certifications/9cd5f3a0-765d-45bc-85c2-bc76d4282599.yml
+++ b/data/certifications/9cd5f3a0-765d-45bc-85c2-bc76d4282599.yml
@@ -3,48 +3,38 @@ name: User Certificate
 description: "Basic user certificate."
 badges:
   agents:
-    flags:
-      - flags.agents.flag_0
-      - flags.agents.flag_1
-      - flags.agents.flag_2
-      - flags.agents.flag_3
-      - flags.agents.flag_4
-      - flags.agents.flag_5
-      - flags.agents.flag_6
-      - flags.agents.flag_7
+    - flags.agents.flag_0:AgentsFlag0
+    - flags.agents.flag_1:AgentsFlag1
+    - flags.agents.flag_2:AgentsFlag2
+    - flags.agents.flag_3:AgentsFlag3
+    - flags.agents.flag_4:AgentsFlag4
+    - flags.agents.flag_5:AgentsFlag5
+    - flags.agents.flag_6:AgentsFlag6
+    - flags.agents.flag_7:AgentsFlag7
   adversaries:
-    flags:
-      - flags.adversaries.flag_0
-      - flags.adversaries.flag_1
-      - flags.adversaries.flag_2
+    - flags.adversaries.flag_0:AdversariesFlag0
+    - flags.adversaries.flag_1:AdversariesFlag1
+    - flags.adversaries.flag_2:AdversariesFlag2
   operations:
-    flags:
-      - flags.operations.flag_0
-      - flags.operations.flag_1
-      - flags.operations.flag_2
-      - flags.operations.flag_3
+    - flags.operations.flag_0:OperationsFlag0
+    - flags.operations.flag_1:OperationsFlag1
+    - flags.operations.flag_2:OperationsFlag2
+    - flags.operations.flag_3:OperationsFlag3
   advanced:
-    flags:
-      - flags.advanced.flag_0
-      - flags.advanced.flag_1
-      - flags.advanced.flag_2
+    - flags.advanced.flag_0:AdvancedFlag0
+    - flags.advanced.flag_1:AdvancedFlag1
+    - flags.advanced.flag_2:AdvancedFlag2
   manx:
-    flags:
-      - flags.plugins.manx.flag_0
-      - flags.plugins.manx.flag_1
+    - flags.plugins.manx.flag_0:PluginsManxFlag0
+    - flags.plugins.manx.flag_1:PluginsManxFlag1
   mock:
-    flags:
-      - flags.plugins.mock.flag_0
+    - flags.plugins.mock.flag_0:PluginsMockFlag0
   compass:
-    flags:
-      - flags.plugins.compass.flag_0
+    - flags.plugins.compass.flag_0:PluginsCompassFlag0
   response:
-    flags:
-      - flags.plugins.response.flag_0
-      - flags.plugins.response.flag_1
+    - flags.plugins.response.flag_0:PluginsResponseFlag0
+    - flags.plugins.response.flag_1:PluginsResponseFlag1
   gameboard:
-    flags:
-      - flags.plugins.gameboard.flag_0
+    - flags.plugins.gameboard.flag_0:PluginsGameboardFlag0
   atomic:
-    flags:
-      - flags.plugins.atomic.flag_0
+    - flags.plugins.atomic.flag_0:PluginsAtomicFlag0

--- a/hook.py
+++ b/hook.py
@@ -60,7 +60,7 @@ async def _load_flags(data_svc):
             for badge, flags in cert['badges'].items():
                 badge = Badge(name=badge)
                 for number, module in enumerate(flags):
-                    module_name, cls_name = ('plugins.training.app.%s' % module).split(':')
+                    module_name, cls_name = ('plugins.training.app.%s' % module).rsplit('.', 1)
                     flag_subclass = getattr(import_module(module_name), cls_name)
                     badge.flags.append(flag_subclass(number=flag_number))
                     flag_number += 1

--- a/hook.py
+++ b/hook.py
@@ -6,19 +6,12 @@ from app.utility.base_world import BaseWorld
 from plugins.training.app.c_badge import Badge
 from plugins.training.app.c_certification import Certification
 from plugins.training.app.c_exam import Exam
-from plugins.training.app.c_fillinblank import FillInBlank
 from plugins.training.app.c_flag import Flag
-from plugins.training.app.c_multiplechoice import MultipleChoice
-from plugins.training.app.c_navigator import Navigator
 from plugins.training.app.training_api import TrainingApi
 
 name = 'Training'
 description = 'A certification course to become a CALDERA SME'
 address = '/plugin/training/gui'
-
-_question_types = dict(multiplechoice=MultipleChoice,
-                       fillinblank=FillInBlank,
-                       navigator=Navigator)
 
 
 async def enable(services):

--- a/static/js/training.js
+++ b/static/js/training.js
@@ -53,7 +53,7 @@ function refresh(){
         return;
     }
     $('#training-disclaimers').hide();
-    restRequest('POST', {"name":selectedCert, "answers":[]}, update, '/plugin/training/flags')
+    restRequest('POST', {"name":selectedCert, "answers":{}}, update, '/plugin/training/flags')
 }
 
 function update(data){


### PR DESCRIPTION
Goals of PR (in no particular order?):
- Make it easier for CALDERA users to define flags
- Reduce code repetition in existing flags
- Abstract flag type (multiplechoice/fillintheblank/navigator) from loading flags into CALDERA instead of checking for `flag_type` attribute
- [~Self registration of flag subclasses~](https://python-3-patterns-idioms-test.readthedocs.io/en/latest/Metaprogramming.html#example-self-registration-of-subclasses)

To-do:
- [X] Test multiplechoice, fill in the blank, and navigator layer upload question types:  [test_data.zip](https://github.com/mitre/training/files/5856894/test_data.zip)
- [X] Test user certificate
- [X] Test blue certificate
- [x] ~Test any remaining implemented flags not in a certificate (these are not currently assigned to any particular certificate, but were created and kept to maybe be included in a future certificate?)~

Flags not in a certificate:
Developers
- flag_0
- flag_1
- flag_2
- flag_3
- flag_4
- flag_5
- flag_6
- flag_7

Manual
- blue_1a
- blue_1b
- blue_3a
- blue_3b
- blue_4a_nix
- blue_4a_win
- blue_4b_nix
- blue_4b_win
- blue_4c_nix
- blue_4c_win
- blue_5a_nix
- blue_5b_nix
- blue_5c_nix
- blue_5d_nix