### PR TITLE
Remove unwanted leading/trailing whitespace from Flag text sections.

### DIFF
--- a/app/flags/agents/flag_0.py
+++ b/app/flags/agents/flag_0.py
@@ -3,12 +3,18 @@ from plugins.training.app.c_flag import Flag
 
 class AgentsFlag0(Flag):
     name = 'Local agent'
-    challenge = 'Demonstrate your ability to deploy an agent on local host. The agent should successfully ' \
-                'beacon back to this server instance.'
-    extra_info = """An agent is another name for Remote Access Trojan (RAT). These programs, written in any language, 
-    execute an adversary's instructions on compromised computers. Often, an agent will communicate back to the 
-    adversary through an internet protocol, such as HTTP, UDP or DNS. Agents give adversaries remote-control access of 
-    the computer running it."""
+
+    challenge = (
+        'Demonstrate your ability to deploy an agent on local host. The agent should successfully '
+        'beacon back to this server instance.'
+    )
+
+    extra_info = (
+        'An agent is another name for Remote Access Trojan (RAT). These programs, written in any language, '
+        'execute an adversary\'s instructions on compromised computers. Often, an agent will communicate back to the '
+        'adversary through an internet protocol, such as HTTP, UDP or DNS. Agents give adversaries remote-control '
+        'access of the computer running it.'
+    )
 
     async def verify(self, services):
         return len(await services.get('data_svc').locate('agents')) > 0

--- a/app/flags/agents/flag_1.py
+++ b/app/flags/agents/flag_1.py
@@ -5,13 +5,19 @@ from plugins.training.app.c_flag import Flag
 
 class AgentsFlag1(Flag):
     name = 'Remote agent'
-    challenge = 'Demonstrate your ability to deploy an agent on a remote host. The agent should successfully ' \
-                'beacon back to this server instance. This agent should be run on an operating system that is NOT' \
-                ' the same as what is hosting the server. It is OK to use a virtual box to complete this challenge.'
-    extra_info = """Adversaries will most likely deploy their command-and-control (C2) server somewhere Internet 
-    accessible. This means their agents will need to have access to the C2 IP address. Computers often have 
-    unrestricted outbound Internet connectivity but heavily restricted inbound connectivity, which is why it's usually 
-    best to have an agent connect to you, not vice-versa."""
+
+    challenge = (
+        'Demonstrate your ability to deploy an agent on a remote host. The agent should successfully '
+        'beacon back to this server instance. This agent should be run on an operating system that is NOT '
+        'the same as what is hosting the server. It is OK to use a virtual box to complete this challenge.'
+    )
+
+    extra_info = (
+        'Adversaries will most likely deploy their command-and-control (C2) server somewhere Internet '
+        'accessible. This means their agents will need to have access to the C2 IP address. Computers often have '
+        'unrestricted outbound Internet connectivity but heavily restricted inbound connectivity, which is why '
+        'it\'s usually best to have an agent connect to you, not vice-versa.'
+    )
 
     async def verify(self, services):
         agents = await services.get('data_svc').locate('agents')

--- a/app/flags/agents/flag_2.py
+++ b/app/flags/agents/flag_2.py
@@ -5,10 +5,12 @@ from plugins.training.app.c_flag import Flag
 class AgentsFlag2(Flag):
     name = 'Understanding trust'
     challenge = 'Change the untrusted agent timer to 60 seconds.'
-    extra_info = """Agents beacon into the C2 on a regular basis, asking the adversary if there are new instructions.
-    If a beacon misses a regularly scheduled interval, there is a chance the agent itself has been discovered and
-    compromised. Defenders may attempt to reverse-engineer the agent and restart it with the intent of
-    learning how it works. """
+    extra_info = (
+        'Agents beacon into the C2 on a regular basis, asking the adversary if there are new instructions. '
+        'If a beacon misses a regularly scheduled interval, there is a chance the agent itself has been discovered and '
+        'compromised. Defenders may attempt to reverse-engineer the agent and restart it with the intent of '
+        'learning how it works.'
+    )
 
     async def verify(self, services):
         if BaseWorld.get_config(name='agents', prop='untrusted_timer') == 60:

--- a/app/flags/agents/flag_3.py
+++ b/app/flags/agents/flag_3.py
@@ -4,10 +4,12 @@ from plugins.training.app.c_flag import Flag
 class AgentsFlag3(Flag):
     name = 'Update agent'
     challenge = 'Pick any agent and change the group and sleep (min and max) values associated to it.'
-    extra_info = """If an agent's beacon time is too regular - or predictable - it runs a higher chance of getting 
-    caught. It is advisable to select a random time range instead of a hard-coded interval. Usually, an adversary 
-    will aim to have multiple agents deployed on a host, with some frequent beacon times and some infrequent.
-    This gives them a backup in case one gets detected."""
+    extra_info = (
+        'If an agent\'s beacon time is too regular - or predictable - it runs a higher chance of getting '
+        'caught. It is advisable to select a random time range instead of a hard-coded interval. Usually, an adversary '
+        'will aim to have multiple agents deployed on a host, with some frequent beacon times and some infrequent. '
+        'This gives them a backup in case one gets detected.'
+    )
 
     async def verify(self, services):
         for a in await services.get('data_svc').locate('agents'):

--- a/app/flags/agents/flag_4.py
+++ b/app/flags/agents/flag_4.py
@@ -4,11 +4,17 @@ from plugins.training.app.c_flag import Flag
 
 class AgentsFlag4(Flag):
     name = 'Agent filename'
-    challenge = 'Ensure that new agents will be named "super_scary" when downloaded on any host. ' \
-                'Note that the extension is automatically appended if necessary.'
-    extra_info = """Adversaries try to blend in when they compromise a host. One common tactic is to name
-    their agent after a program that is already running on the host. When defenders check process lists
-    and file names, the name has a higher chance of blending in."""
+
+    challenge = (
+        'Ensure that new agents will be named "super_scary" when downloaded on any host. '
+        'Note that the extension is automatically appended if necessary.'
+    )
+
+    extra_info = (
+        'Adversaries try to blend in when they compromise a host. One common tactic is to name '
+        'their agent after a program that is already running on the host. When defenders check process lists '
+        'and file names, the name has a higher chance of blending in.'
+    )
 
     async def verify(self, services):
         if BaseWorld.get_config(name='agents', prop='implant_name') == 'super_scary':

--- a/app/flags/agents/flag_5.py
+++ b/app/flags/agents/flag_5.py
@@ -4,13 +4,19 @@ from plugins.training.app.c_flag import Flag
 
 class AgentsFlag5(Flag):
     name = 'Bootstrap abilities'
-    challenge = 'Using a Stockpile ability, ensure new agents automatically run "whoami" on their first beacon. ' \
-                'Locate the ability that executes this command and enter the ability id as a bootstrap ability ' \
-                '(Hint: Abilities and their id can be found in the `plugins/stockpile/data/abilities` directory).'
-    extra_info = """Depending on the defensive tools installed on a compromised machine, an adversary may need to 
-    execute their mission quickly before getting detected and shut down. One common tactic is to give each new agent a 
-    set of instructions to run immediately after sending the first beacon in. These instructions may determine what 
-    software is installed on the host, to gain persistence or any another tactic."""
+
+    challenge = (
+        'Using a Stockpile ability, ensure new agents automatically run "whoami" on their first beacon. '
+        'Locate the ability that executes this command and enter the ability id as a bootstrap ability '
+        '(Hint: Abilities and their id can be found in the `plugins/stockpile/data/abilities` directory).'
+    )
+
+    extra_info = (
+        'Depending on the defensive tools installed on a compromised machine, an adversary may need to '
+        'execute their mission quickly before getting detected and shut down. One common tactic is to give '
+        'each new agent a set of instructions to run immediately after sending the first beacon in. These '
+        'instructions may determine what software is installed on the host, to gain persistence or any another tactic.'
+    )
 
     async def verify(self, services):
         abilities = BaseWorld.get_config(name='agents', prop='bootstrap_abilities')

--- a/app/flags/agents/flag_6.py
+++ b/app/flags/agents/flag_6.py
@@ -4,9 +4,12 @@ from plugins.training.app.c_flag import Flag
 class AgentsFlag6(Flag):
     name = 'Contact points'
     challenge = 'Deploy a new agent, using a different contact point then your first agent'
-    extra_info = """If an adversary deploys all of their agents on a host using the same protocol, say HTTP, then when 
-    their agent is detected and shut down, the defenders will likely close access to the C2 over that protocol. 
-    Therefore, an adversary will want multiple agents on a host, each using a different protocol to talk to the C2. """
+    extra_info = (
+        'If an adversary deploys all of their agents on a host using the same protocol, say HTTP, then when '
+        'their agent is detected and shut down, the defenders will likely close access to the C2 over that protocol. '
+        'Therefore, an adversary will want multiple agents on a host, each using a different protocol to talk to '
+        'the C2.'
+    )
 
     async def verify(self, services):
         contacts = set([agent.contact for agent in await services.get('data_svc').locate('agents')])

--- a/app/flags/agents/flag_7.py
+++ b/app/flags/agents/flag_7.py
@@ -4,9 +4,11 @@ from plugins.training.app.c_flag import Flag
 class AgentsFlag7(Flag):
     name = 'Kill agent'
     challenge = 'Kill one of your agents through the GUI'
-    extra_info = """In red-team engagements, operators often need to clean up the environments under test at the end
-    of the testing. Going through box-by-box can be time-consuming, so using automation to auto-stop agents is 
-    preferred. """
+    extra_info = (
+        'In red-team engagements, operators often need to clean up the environments under test at the end '
+        'of the testing. Going through box-by-box can be time-consuming, so using automation to auto-stop agents is '
+        'preferred.'
+    )
 
     async def verify(self, services):
         for a in await services.get('data_svc').locate('agents'):

--- a/app/flags/plugins/atomic/flag_0.py
+++ b/app/flags/plugins/atomic/flag_0.py
@@ -4,9 +4,11 @@ from plugins.training.app.c_flag import Flag
 class PluginsAtomicFlag0(Flag):
     name = 'Atomic plugin'
     challenge = 'As a red user, enable the Atomic plugin and verify that new abilities have been added to the database'
-    extra_info = """There are lots of sources for TTPs on the Internet, and more are added daily. These TTPs can be in 
-    any format and in any language. It is possible, and often trivial, to import them into CALDERA for use in 
-    operations."""
+    extra_info = (
+        'There are lots of sources for TTPs on the Internet, and more are added daily. These TTPs can be in '
+        'any format and in any language. It is possible, and often trivial, to import them into CALDERA for use in '
+        'operations.'
+    )
 
     async def verify(self, services):
         for _ in await services.get('data_svc').locate('plugins', dict(enabled=True, name='atomic')):

--- a/app/flags/plugins/manx/flag_0.py
+++ b/app/flags/plugins/manx/flag_0.py
@@ -3,11 +3,17 @@ from plugins.training.app.c_flag import Flag
 
 class PluginsManxFlag0(Flag):
     name = 'Manx plugin'
-    challenge = 'Start a new Manx agent on your localhost. Then send at least 2 commands to it through the ' \
-                'reverse-shell session. Then run a normal operation against the agent using the Hunter profile.'
-    extra_info = """One of the most common activities a red-team operator will attempt to do is gain a reverse-shell 
-    on a compromised host. This type of shell is a persistent (usually via TCP) connection which gives the operator a 
-    terminal experience that is as-if they are sitting behind the keyboard on the remote host."""
+
+    challenge = (
+        'Start a new Manx agent on your localhost. Then send at least 2 commands to it through the '
+        'reverse-shell session. Then run a normal operation against the agent using the Hunter profile.'
+    )
+
+    extra_info = (
+        'One of the most common activities a red-team operator will attempt to do is gain a reverse-shell '
+        'on a compromised host. This type of shell is a persistent (usually via TCP) connection which gives '
+        'the operator a terminal experience that is as-if they are sitting behind the keyboard on the remote host.'
+    )
 
     async def verify(self, services):
         check1, check2 = False, False

--- a/app/flags/plugins/manx/flag_1.py
+++ b/app/flags/plugins/manx/flag_1.py
@@ -4,10 +4,12 @@ from plugins.training.app.c_flag import Flag
 class PluginsManxFlag1(Flag):
     name = 'Manx UDP'
     challenge = 'Start a new Manx agent in UDP mode'
-    extra_info = """If an adversary is having trouble getting an agent to connect outbound over popular protocols, like 
-    HTTP or TCP, they will often fallback to UDP. Because DNS goes over UDP, this protocol is usually more accessible 
-    than others. In addition, lazy system administrators may forget to add firewall rules on UDP ports whereas TCP is 
-    the default in most firewall tools."""
+    extra_info = (
+        'If an adversary is having trouble getting an agent to connect outbound over popular protocols, like '
+        'HTTP or TCP, they will often fallback to UDP. Because DNS goes over UDP, this protocol is usually more '
+        'accessible than others. In addition, lazy system administrators may forget to add firewall rules on UDP '
+        'ports whereas TCP is the default in most firewall tools.'
+    )
 
     async def verify(self, services):
         for _ in await services.get('data_svc').locate('agents', dict(contact='udp')):


### PR DESCRIPTION
## Description
Fixed some unwanted line breaks and whitespace issues with training flags.

This was accomplished by replacing uses multi-line triple-quoted string literals with multi-line literals inside parentheses. I also replaced instances of `\` escaped line breaks with the parentheses-based joining.

Note that I only updated the Agent, Manx, and Atomic flags. @domainicus is going to be updating other flags under the User certificate.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
I modified the `training.js` file to show all flags (i may have been able to add a certificate type to the yaml file?)  and looked at all the updated flags in my browser to verify that the text whitespace issues had been resolved.


## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

N/A
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
