### PR TITLE
Fix bug with Gameboard flag verification

### DIFF
--- a/app/flags/plugins/gameboard/flag_0.py
+++ b/app/flags/plugins/gameboard/flag_0.py
@@ -16,4 +16,5 @@ class PluginsGameboardFlag0(Flag):
                                                                        name='Gameboard - Red'))
         blue = await services.get('data_svc').locate('operations', dict(access=BaseWorld.Access.BLUE,
                                                                         name='Gameboard - Blue'))
-        return all(red + blue)
+
+        return bool(red and blue)


### PR DESCRIPTION
## Description
Fixes an issue with the gameboard flag verification, where it would return `True` even if no required operations had been created.

This is due to how `all()` functions in python when passed in an empty iterable:

```python
>>> all([])
True
```

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
I ran the server with `--fresh` and set up the user certificate to show me that flag (i set the `cert_type` to `exam` but there are lotsa ways to do this). I then confirmed that the gameboard plugin was not auto-completed like it was before. I then went through the flag steps and verified that the flag did not complete until both operations had been created.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
