### PR TITLE
[VIRTS-1891] Disable the compass training flag in the user certificate.

### DIFF
--- a/data/certifications/9cd5f3a0-765d-45bc-85c2-bc76d4282599.yml
+++ b/data/certifications/9cd5f3a0-765d-45bc-85c2-bc76d4282599.yml
@@ -29,8 +29,6 @@ badges:
     - flags.plugins.manx.flag_1.PluginsManxFlag1
   mock:
     - flags.plugins.mock.flag_0.PluginsMockFlag0
-  compass:
-    - flags.plugins.compass.flag_0.PluginsCompassFlag0
   response:
     - flags.plugins.response.flag_0.PluginsResponseFlag0
     - flags.plugins.response.flag_1.PluginsResponseFlag1


### PR DESCRIPTION
## Description
This PR disables the Compass training flag in the User certification. We are going to be reworking this flag in VIRTS-1847.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
After making the change I restarted the server and verified that the flag and badge disappeared from the user certification.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code

