### PR TITLE
[VIRTS-1915] Added media queries to fix overflow of text in training cards

### DIFF
--- a/static/css/training.css
+++ b/static/css/training.css
@@ -6,7 +6,25 @@
     right: 0;
     margin: 20px;
     position:absolute;
-    font-size: 40px;
+    font-size: 10px;
+}
+@media only screen and (min-width: 700px) {
+    .flag-box h1 {
+        font-size: 20px;
+    }
+}
+@media only screen and (min-width: 900px) {
+    .flag-box h1 {
+        font-size: 30px;
+    }
+}
+@media only screen and (min-width: 1400px) {
+    .flag-box h1 {
+        font-size: 40px;
+    }
+}
+#flag-challenge {
+    word-break: break-word;
 }
 .flag-box p {
     font-size:13px;
@@ -59,15 +77,33 @@ div.badge-completed{
     background-color: darkgreen;
 }
 .flip-card {
+    height: 975px;
     background-color: transparent;
-    height: 300px;
     perspective: 1000px;
-    width: 25%;
+    width: 30%;
     color: white;
     padding: 20px;
     margin: 5px;
-    min-height:350px;
+    min-height: 350px;
     position: relative;
+}
+@media only screen and (min-width: 700px) {
+    .flip-card {
+        height: 800px;
+        width: 30%;
+    }
+}
+@media only screen and (min-width: 900px) {
+    .flip-card {
+        height: 600px;
+        width: 30%;
+    }
+}
+@media only screen and (min-width: 1400px) {
+    .flip-card {
+        height: 400px;
+        width: 25%;
+    }
 }
 .flip-card-inner {
   position: relative;


### PR DESCRIPTION
## Description

(insert summary)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

Ran Caldera app locally on Chrome browser, and verified text overflow bug has been fixed with responsive card heights.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation [n/a]
- [ ] I have added tests that prove my fix is effective or that my feature works [n/a]
