### PR TITLE
Fix issue where solution guide button is clickable even when guide does not exist

### DIFF
--- a/app/c_flag.py
+++ b/app/c_flag.py
@@ -39,7 +39,8 @@ class Flag(BaseObject):
         return dict(number=self.number, name=self.name, challenge=self.challenge, completed=self.completed,
                     extra_info=self.extra_info, code=self.calculate_code(),
                     completed_timestamp=self._convert_timestamp(),
-                    resettable=self._is_resettable())
+                    resettable=self._is_resettable(),
+                    has_solution_guide = self.has_solution_guide)
 
     @property
     def solution_guide_filename(self):

--- a/templates/training.html
+++ b/templates/training.html
@@ -124,6 +124,7 @@
                                 <p x-text="flag.name"></p>
                             </div>
                             <a class="icon has-tooltip-left solution-guide-link"
+                               x-bind:class="flag.has_solution_guide ? '' : 'hidden'"
                                x-bind:href="`/plugin/training/solution-guides/certificates/${flag.cert_name}/badges/${flag.badge_name}/flags/${flag.name}`"
                                target="_blank"
                                data-tooltip="Solution Guide">
@@ -426,6 +427,11 @@
     #trainingPage .solution-guide-link {
         color: white;
         cursor: pointer;
+    }
+
+    #trainingPage .hidden {
+        pointer-events: none;
+        color: grey;
     }
 
     #trainingPage .badge-container {


### PR DESCRIPTION
## Description

Previously the solution guide flag button would be clickable even when no solution guide exists, specifically the Blue Certificate trainings which have no guides. Now the flag api returns the "has_solution_guide" flag so that the hidden css class can be added if the "has_solution_guide" flag is false. 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Verified across browsers (Safari/Chrome/Firefox) that the solution guide button is clickable for flags where the solution guide exists (User Certificate) and is greyed out and un-clickable for flags where the solution guide does not exist.

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
