### PR TITLE
Fixed Manx flag and changed operations to Check

### DIFF
--- a/app/flags/operations/flag_0.py
+++ b/app/flags/operations/flag_0.py
@@ -3,7 +3,7 @@ from plugins.training.app.c_flag import Flag
 
 class OperationsFlag0(Flag):
     name = 'Basic operation'
-    challenge = 'Run and finish an operation. Use the Ransack adversary profile provided in the Stockpile plugin.'
+    challenge = 'Run and finish an operation. Use the Check adversary profile provided in the Stockpile plugin.'
     extra_info = (
         'An autonomous operation uses an adversary profile to pre-configures the attack. Agents and C2 run '
         'without operator interference. This allows operators to run repeatable adversary emulation '
@@ -12,6 +12,6 @@ class OperationsFlag0(Flag):
 
     async def verify(self, services):
         for op in await services.get('data_svc').locate('operations'):
-            if op.finish and op.adversary.adversary_id == 'de07f52d-9928-4071-9142-cb1d3bd851e8':
+            if op.finish and op.adversary.adversary_id == '01d77744-2515-401a-a497-d9f7241aac3c':
                 return True
         return False

--- a/app/flags/operations/flag_1.py
+++ b/app/flags/operations/flag_1.py
@@ -5,7 +5,7 @@ class OperationsFlag1(Flag):
     name = 'Stealthy operation'
 
     challenge = (
-        'Run and finish an operation using a jitter of 10/20 and base64 obfuscation. Use the Ransack adversary profile '
+        'Run and finish an operation using a jitter of 10/20 and base64 obfuscation. Use the Check adversary profile '
         'provided in the Stockpile plugin again.'
     )
 
@@ -19,7 +19,7 @@ class OperationsFlag1(Flag):
 
     async def verify(self, services):
         for op in await services.get('data_svc').locate('operations'):
-            if op.finish and op.adversary.adversary_id == 'de07f52d-9928-4071-9142-cb1d3bd851e8' \
+            if op.finish and op.adversary.adversary_id == '01d77744-2515-401a-a497-d9f7241aac3c' \
                     and op.obfuscator == 'base64' and op.jitter == '10/20':
                 return True
         return False

--- a/app/flags/operations/flag_2.py
+++ b/app/flags/operations/flag_2.py
@@ -5,7 +5,7 @@ class OperationsFlag2(Flag):
     name = 'Manual operation'
 
     challenge = (
-        'Run and finish an operation using any adversary profile except Ransack. Run the operation requiring manual '
+        'Run and finish an operation using any adversary profile except Check. Run the operation requiring manual '
         'approval. Approve and discard links as desired.'
     )
 
@@ -17,6 +17,6 @@ class OperationsFlag2(Flag):
 
     async def verify(self, services):
         for op in await services.get('data_svc').locate('operations'):
-            if op.finish and op.adversary.adversary_id != 'de07f52d-9928-4071-9142-cb1d3bd851e8' and not op.autonomous:
+            if op.finish and op.adversary.adversary_id != '01d77744-2515-401a-a497-d9f7241aac3c' and not op.autonomous:
                 return True
         return False

--- a/app/flags/plugins/manx/flag_0.py
+++ b/app/flags/plugins/manx/flag_0.py
@@ -6,7 +6,7 @@ class PluginsManxFlag0(Flag):
 
     challenge = (
         'Start a new Manx agent on your localhost. Then send at least 2 commands to it through the '
-        'reverse-shell session. Then run a normal operation against the agent using the Ransack profile.'
+        'reverse-shell session. Then run a normal operation against the agent using the Check profile.'
     )
 
     extra_info = (
@@ -18,11 +18,11 @@ class PluginsManxFlag0(Flag):
     async def verify(self, services):
         check1, check2 = False, False
         for agent in await services.get('data_svc').locate('agents', dict(contact='tcp')):
-            history = [entry for entry in services.get('contact_svc').report['websocket'] if entry['paw'] == agent.paw]
+            history = [entry for entry in services.get('contact_svc').report['WEBSOCKET'] if entry['paw'] == agent.paw]
             if len(history) > 1:
                 check1 = True
             for op in await services.get('data_svc').locate('operations'):
-                if op.adversary.adversary_id != 'de07f52d-9928-4071-9142-cb1d3bd851e8':
+                if op.adversary.adversary_id != '01d77744-2515-401a-a497-d9f7241aac3c':
                     continue
                 for op_agent in op.agents:
                     if op_agent.paw == agent.paw and op.finish:

--- a/app/flags/plugins/manx/flag_0.py
+++ b/app/flags/plugins/manx/flag_0.py
@@ -18,7 +18,7 @@ class PluginsManxFlag0(Flag):
     async def verify(self, services):
         check1, check2 = False, False
         for agent in await services.get('data_svc').locate('agents', dict(contact='tcp')):
-            history = [entry for entry in services.get('contact_svc').report['WEBSOCKET'] if entry['paw'] == agent.paw]
+            history = [entry for entry in services.get('contact_svc').report['websocket'] if entry['paw'] == agent.paw]
             if len(history) > 1:
                 check1 = True
             for op in await services.get('data_svc').locate('operations'):

--- a/app/flags/plugins/mock/flag_0.py
+++ b/app/flags/plugins/mock/flag_0.py
@@ -4,7 +4,7 @@ from plugins.training.app.c_flag import Flag
 class PluginsMockFlag0(Flag):
     name = 'Mock plugin'
     challenge = (
-        'Enable the mock plugin. Then run an operation against the "simulation" group using the Ransack profile. '
+        'Enable the mock plugin. Then run an operation against the "simulation" group using the Check profile. '
         '(Hint: check default.yml for running plugins.)'
     )
     extra_info = (
@@ -16,6 +16,6 @@ class PluginsMockFlag0(Flag):
     async def verify(self, services):
         if await services.get('data_svc').locate('plugins', dict(name='mock', enabled=True)):
             for op in await services.get('data_svc').locate('operations', dict(group='simulation')):
-                if op.finish and op.adversary.adversary_id == 'de07f52d-9928-4071-9142-cb1d3bd851e8':
+                if op.finish and op.adversary.adversary_id == '01d77744-2515-401a-a497-d9f7241aac3c':
                     return True
         return False

--- a/solution_guides/OperationsFlag0.md
+++ b/solution_guides/OperationsFlag0.md
@@ -2,7 +2,7 @@
 1. Select `CAMPAIGNS > operations`.
 1. Click the `+ Create Operation` button to open the `Start New Operation` menu.
 1. Give the operation a name.
-1. Select the `Ransack` adversary from the `Adversary` dropdown.
+1. Select the `Check` adversary from the `Adversary` dropdown.
 1. Select `basic` from the `Fact source` menu.
 1. Press `ADVANCED` to open the advanced options dialog.
 1. Select `Auto close operation` from the `Auto-close`radio group.

--- a/solution_guides/OperationsFlag1.md
+++ b/solution_guides/OperationsFlag1.md
@@ -2,7 +2,7 @@
 1. Select `CAMPAIGNS > operations`.
 1. Click the `+ Create Operation` button to open the `Start New Operation` menu.
 1. Give the operation a name.
-1. Select the `Ransack` adversary from the `Adversary` dropdown.
+1. Select the `Check` adversary from the `Adversary` dropdown.
 1. Select `basic` from the `Fact source` menu.
 1. Press `ADVANCED` to open the advanced options dialog.
 1. In the `Obfuscators` button group, choose `base64`.

--- a/solution_guides/PluginsManxFlag0.md
+++ b/solution_guides/PluginsManxFlag0.md
@@ -14,11 +14,11 @@
     1. Select the Agent session from the `Select a session` dropdown. This should populate the remote shell window with a prompt.
     1. In the remote shell, type `whoami` and press enter.
     1. In the remote shell, type `uname -a` and press enter.
-1. Run `Ransack` operation:
+1. Run `Check` operation:
     1. In the left-handside navigation, select `CAMPAIGNS > operations`.
     1. Click the `+ Create Operation` button to open the `Start New Operation` menu.
     1. Give the operation a name.
-    1. Select the `Ransack` adversary from the `Adversary` dropdown.
+    1. Select the `Check` adversary from the `Adversary` dropdown.
     1. Select `basic` from the `Fact source` menu.
     1. Press `ADVANCED` to open the advanced options dialog.
     1. Select `Auto close operation` from the `Auto-close`radio group.

--- a/solution_guides/PluginsMockFlag0.md
+++ b/solution_guides/PluginsMockFlag0.md
@@ -9,7 +9,7 @@
 1. Click the `+ Create Operation` button to open the `Start New Operation` menu.
 1. Give the operation a name.
 1. In the `Group`, select `simulation`.
-1. Select the `Ransack` adversary from the `Adversary` dropdown.
+1. Select the `Check` adversary from the `Adversary` dropdown.
 1. Select `basic` from the `Fact source` menu.
 1. Press `ADVANCED` to open the advanced options dialog.
 1. Select `Auto close operation` from the `Auto-close`radio group.


### PR DESCRIPTION
## Description

Manx plugin training flag currently has a bug where the history field is not populated due to case sensitivity of the string. The current version uses `.report['websocket']`. This will return an empty list, and thus never populate the `history` variable.

Capitalizing to `WEBSOCKET` allows for the `history` variable to be populated.

Also changed from `RANSACK` to `CHECK` adversary to reduce the time spent running the operation.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Created breakpoints and print statements in the affected code. Tested by using terminal to enter commands to trigger check1 and an operation to trigger check2. Ensured that changes triggered flag appropriately.

![image](https://user-images.githubusercontent.com/81784737/183147853-d61cde38-ba4f-44a5-89c1-f20ce2b09cc9.png)
![image](https://user-images.githubusercontent.com/81784737/183147897-2773d8a7-3fd4-4eae-bf75-4a64b8e3051d.png)
![image](https://user-images.githubusercontent.com/81784737/183148503-4be35e38-d37e-4cd4-9f89-423ea1a20131.png)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
