### PR TITLE
Add GitHub Actions workflows to match caldera core

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,0 +1,19 @@
+name: Greetings
+
+on: [pull_request, issues]
+
+permissions:
+  contents: read
+
+jobs:
+  greeting:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - uses: actions/first-interaction@1d8459ca65b335265f1285568221e229d45a995e
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        issue-message: 'Looks like your first issue -- we aim to respond to issues as quickly as possible. In the meantime, check out our documentation here: http://caldera.readthedocs.io/'
+        pr-message: 'Wohoo! Your first PR -- thanks for contributing!'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,26 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+permissions:
+  contents: read
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+    - uses: actions/stale@a20b814fb01b71def3bd6f56e7494d667ddf28da
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'
+        stale-pr-message: 'This pull request is stale because it has had no activity for 60 days. Remove the stale label or comment or this will be closed in 60 days'
+        stale-issue-message: 'This issue is stale because it has had no activity for 60 days. Remove the stale label or comment or this will be closed in 60 days'
+        exempt-issue-labels: 'feature,keep'
+        days-before-stale: 60
+        days-before-close: 60


### PR DESCRIPTION
## Summary

This PR adds GitHub Actions workflows to match the caldera core repository.

### Workflows added:
- **stale.yml**: Automatically marks issues and pull requests as stale after 60 days of inactivity, and closes them after another 60 days.
- **greetings.yml**: Greets first-time contributors when they open an issue or pull request.

The existing `javascript-lint.yml` workflow is untouched. All actions are pinned to specific SHAs for security.