### PR TITLE
fix(training): verify hashed training user password

### DIFF
--- a/app/flags/advanced/flag_2.py
+++ b/app/flags/advanced/flag_2.py
@@ -1,3 +1,4 @@
+from app.utility.config_util import verify_hash
 from plugins.training.app.c_flag import Flag
 
 
@@ -12,4 +13,4 @@ class AdvancedFlag2(Flag):
 
     async def verify(self, services):
         user = services.get('auth_svc').user_map.get('test')
-        return user and user.password == 'test' and 'red' in user.permissions
+        return user and verify_hash(user.password, 'test') and 'red' in user.permissions

--- a/tests/app/flags/advanced/test_flag2.py
+++ b/tests/app/flags/advanced/test_flag2.py
@@ -1,6 +1,6 @@
 """Tests for advanced flag_2 (AdvancedFlag2)."""
 import pytest
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import MagicMock, patch
 
 from plugins.training.app.flags.advanced.flag_2 import AdvancedFlag2
 
@@ -15,11 +15,13 @@ class TestAdvancedFlag2:
     async def test_verify_correct_user(self):
         f = AdvancedFlag2(number=1)
         user = MagicMock()
-        user.password = 'test'
+        user.password = 'hashed-test-password'
         user.permissions = ['red']
         services = {'auth_svc': MagicMock()}
         services['auth_svc'].user_map = {'test': user}
-        assert await f.verify(services) is True
+        with patch('plugins.training.app.flags.advanced.flag_2.verify_hash', return_value=True) as verify_hash:
+            assert await f.verify(services) is True
+        verify_hash.assert_called_once_with('hashed-test-password', 'test')
 
     @pytest.mark.asyncio
     async def test_verify_no_user(self):
@@ -32,18 +34,22 @@ class TestAdvancedFlag2:
     async def test_verify_wrong_password(self):
         f = AdvancedFlag2(number=1)
         user = MagicMock()
-        user.password = 'wrong'
+        user.password = 'hashed-wrong-password'
         user.permissions = ['red']
         services = {'auth_svc': MagicMock()}
         services['auth_svc'].user_map = {'test': user}
-        assert await f.verify(services) is False
+        with patch('plugins.training.app.flags.advanced.flag_2.verify_hash', return_value=False) as verify_hash:
+            assert await f.verify(services) is False
+        verify_hash.assert_called_once_with('hashed-wrong-password', 'test')
 
     @pytest.mark.asyncio
     async def test_verify_no_red_permission(self):
         f = AdvancedFlag2(number=1)
         user = MagicMock()
-        user.password = 'test'
+        user.password = 'hashed-test-password'
         user.permissions = ['blue']
         services = {'auth_svc': MagicMock()}
         services['auth_svc'].user_map = {'test': user}
-        assert await f.verify(services) is False
+        with patch('plugins.training.app.flags.advanced.flag_2.verify_hash', return_value=True) as verify_hash:
+            assert await f.verify(services) is False
+        verify_hash.assert_called_once_with('hashed-test-password', 'test')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,14 @@ sys.modules['app'] = types.ModuleType('app')
 sys.modules['app.utility'] = types.ModuleType('app.utility')
 sys.modules['app.utility.base_object'] = _base_object_mod
 
+def _verify_hash(hash_val, target):
+    return False
+
+
+_config_util_mod = types.ModuleType('app.utility.config_util')
+_config_util_mod.verify_hash = _verify_hash
+sys.modules['app.utility.config_util'] = _config_util_mod
+
 _base_world_mod = types.ModuleType('app.utility.base_world')
 
 class _Access:


### PR DESCRIPTION
## Description

Fix the Advanced training badge's “Add new user” flag so it verifies the configured `test` user's Argon2 password hash through Caldera's standard `verify_hash` helper.

The previous direct plaintext comparison always failed after Caldera began hashing user passwords during startup. Add regression coverage for successful, invalid-password, and missing-permission cases.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Ran the Advanced training-flag test group: 42 passed.
- Ran Flake8 on the changed production and regression-test files.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works